### PR TITLE
Improve swagger

### DIFF
--- a/Pirat/Codes/Error.cs
+++ b/Pirat/Codes/Error.cs
@@ -2,6 +2,7 @@
 {
     public class Error
     {
+
         public static class ErrorCodes
         {
 
@@ -9,6 +10,7 @@
             public const string INVALID_MAIL = "1001:InvalidMail";
             public const string INVALID_AMOUNT_CONSUMABLE = "1002:InvalidAmountConsumable";
             public const string INVALID_AMOUNT_DEVICE = "1003:InvalidAmountDevice";
+            public const string INVALID_TOKEN = "1004:InvalidToken";
 
             public const string INCOMPLETE_ADDRESS = "2000:IncompleteAddress";
             public const string INCOMPLETE_OFFER = "2001:IncompleteOffer";
@@ -16,7 +18,6 @@
             public const string INCOMPLETE_CONSUMABLE = "2003:IncompleteConsumable";
             public const string INCOMPLETE_DEVICE = "2004:IncompleteDevice";
             public const string INCOMPLETE_PERSONAL = "2005:IncompletePersonal";
-            public const string INCOMPLETE_TOKEN = "2006:IncompleteToken";
 
             public const string NOTFOUND_ADDRESS = "3000:NotFoundAddress";
             public const string NOTFOUND_OFFER = "3001:NotFoundOffer";

--- a/Pirat/Controllers/DemandController.cs
+++ b/Pirat/Controllers/DemandController.cs
@@ -14,6 +14,8 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Formatters.Xml;
 using Pirat.Codes;
 using Pirat.Model.Entity;
+using Pirat.SwaggerConfiguration;
+using Swashbuckle.AspNetCore.Filters;
 
 namespace Pirat.Controllers
 {
@@ -46,7 +48,14 @@ namespace Pirat.Controllers
 
         //***********GET REQUESTS
 
-
+        /// <summary>
+        /// Searches list of Consumables and the associated Provider. Provider only included if public.
+        /// </summary>
+        /// <param name="consumable"></param>
+        /// <param name="address"></param>
+        /// <returns>List of consumables</returns>
+        /// <response code="200">Returns the list of consumables. Empty if no consumable found.</response>
+        /// <response code="400">If arguments in the query are invalid.</response> 
         [HttpGet("consumables")]
         [ProducesResponseType(typeof(List<OfferResource<Consumable>>), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
@@ -70,7 +79,14 @@ namespace Pirat.Controllers
         }
 
 
-
+        /// <summary>
+        /// Searches list of Devices and the associated Provider. Provider only included if public
+        /// </summary>
+        /// <param name="device"></param>
+        /// <param name="address"></param>
+        /// <returns>List of devices</returns>
+        /// <response code="200">Returns the list of devices. Empty if no device found.</response>
+        /// <response code="400">If arguments in the query are invalid.</response> 
         [HttpGet("devices")]
         [ProducesResponseType(typeof(List<OfferResource<Device>>), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
@@ -93,6 +109,14 @@ namespace Pirat.Controllers
             }
         }
 
+        /// <summary>
+        /// Searches lift of Personals and the associated Provider. Provider only included if public.
+        /// </summary>
+        /// <param name="manpower"></param>
+        /// <param name="address"></param>
+        /// <returns>List of personals</returns>
+        /// <response code="200">Returns the list of personals. Empty if no personal found.</response>
+        /// <response code="400">If arguments in the query are invalid.</response> 
         [HttpGet("manpower")]
         [ProducesResponseType(typeof(List<OfferResource<Personal>>), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
@@ -116,6 +140,14 @@ namespace Pirat.Controllers
            
         }
 
+        /// <summary>
+        /// Searches the Offer for the given token.
+        /// </summary>
+        /// <param name="token"></param>
+        /// <returns>The offer of the token</returns>
+        /// <response code="200">Returns the offer.</response>
+        /// <response code="400">If token is invalid</response>
+        /// <response code="404">If no offer for the token exists</response> 
         [HttpGet("offers/{token}")]
         [ProducesResponseType(typeof(Offer), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(string), StatusCodes.Status404NotFound)]
@@ -141,12 +173,35 @@ namespace Pirat.Controllers
 
         //*********POST REQUESTS
 
-
+        /// <summary>
+        /// Creates an offer.
+        /// </summary>
+        /// <remarks>
+        /// Sample request:
+        /// 
+        ///     POST /resources
+        ///     {
+        ///         "provider": {
+        ///             "address": {
+        ///                 "street": "Hauptstrasse",
+        ///                 "streetnumber": "1",
+        ///                 "postalcode": "80333",
+        ///                 "city": "München",
+        ///                 "country": "Deutschland",
+        ///                 "latitude": 0,
+        ///                 "longitude": 0
+        ///     }
+        /// </remarks>
+        /// <param name="offer"></param>
+        /// <returns>A newly created offer</returns>
+        /// <response code="200">Returns the newly created offer</response>
+        /// <response code="400">If data in the offer is invalid or not sufficient</response>
         [HttpPost]
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
         [Consumes("application/json")]
         [Produces("application/json")]
+        [SwaggerRequestExample(typeof(Offer), typeof(OfferModelExample))]
         public async Task<IActionResult> Post([FromBody] Offer offer)
         {
             try

--- a/Pirat/Controllers/ResourceController.cs
+++ b/Pirat/Controllers/ResourceController.cs
@@ -10,11 +10,14 @@ using Pirat.Services;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Formatters.Xml;
 using Pirat.Codes;
+using Pirat.Extensions.Swagger.SwaggerConfiguration;
 using Pirat.Model.Entity;
 using Pirat.SwaggerConfiguration;
+using Swashbuckle.AspNetCore.Annotations;
 using Swashbuckle.AspNetCore.Filters;
 
 namespace Pirat.Controllers
@@ -22,10 +25,10 @@ namespace Pirat.Controllers
 
     [ApiController]
     [Route("/resources")]
-    public class DemandController : ControllerBase
+    public class ResourceController : ControllerBase
     {
 
-        private readonly ILogger<DemandController> _logger;
+        private readonly ILogger<ResourceController> _logger;
 
         private readonly IDemandService _demandService;
 
@@ -33,8 +36,8 @@ namespace Pirat.Controllers
 
         private readonly IReCaptchaService _reCaptchaService;
 
-        public DemandController(
-            ILogger<DemandController> logger,
+        public ResourceController(
+            ILogger<ResourceController> logger,
             IDemandService demandService,
             IMailService mailService,
             IReCaptchaService reCaptchaService
@@ -57,10 +60,12 @@ namespace Pirat.Controllers
         /// <response code="200">Returns the list of consumables. Empty if no consumable found.</response>
         /// <response code="400">If arguments in the query are invalid.</response> 
         [HttpGet("consumables")]
-        [ProducesResponseType(typeof(List<OfferResource<Consumable>>), StatusCodes.Status200OK)]
-        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
         [Consumes("application/json")]
         [Produces("application/json")]
+        [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(List<OfferResource<Consumable>>))]
+        [SwaggerResponseExample(StatusCodes.Status200OK, typeof(OfferConsumableResponseExample))]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(ErrorCodeResponseExample))]
         public async Task<IActionResult> Get([FromQuery] Consumable consumable, [FromQuery] Address address)
         {
             try
@@ -88,10 +93,12 @@ namespace Pirat.Controllers
         /// <response code="200">Returns the list of devices. Empty if no device found.</response>
         /// <response code="400">If arguments in the query are invalid.</response> 
         [HttpGet("devices")]
-        [ProducesResponseType(typeof(List<OfferResource<Device>>), StatusCodes.Status200OK)]
-        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
         [Consumes("application/json")]
         [Produces("application/json")]
+        [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(List<OfferResource<Device>>))]
+        [SwaggerResponseExample(StatusCodes.Status200OK, typeof(OfferDeviceResponseExample))]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(ErrorCodeResponseExample))]
         public async Task<IActionResult> Get([FromQuery] Device device, [FromQuery] Address address)
         {
             try
@@ -118,10 +125,12 @@ namespace Pirat.Controllers
         /// <response code="200">Returns the list of personals. Empty if no personal found.</response>
         /// <response code="400">If arguments in the query are invalid.</response> 
         [HttpGet("manpower")]
-        [ProducesResponseType(typeof(List<OfferResource<Personal>>), StatusCodes.Status200OK)]
-        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
         [Consumes("application/json")]
         [Produces("application/json")]
+        [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(List<OfferResource<Personal>>))]
+        [SwaggerResponseExample(StatusCodes.Status200OK, typeof(OfferPersonalResponseExample))]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(ErrorCodeResponseExample))]
         public async Task<IActionResult> Get([FromQuery] Manpower manpower, [FromQuery] Address address)
         {
             try
@@ -149,11 +158,13 @@ namespace Pirat.Controllers
         /// <response code="400">If token is invalid</response>
         /// <response code="404">If no offer for the token exists</response> 
         [HttpGet("offers/{token}")]
+        [Consumes("application/json")]
+        [Produces("application/json")]
         [ProducesResponseType(typeof(Offer), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(string), StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [Consumes("application/json")]
-        [Produces("application/json")]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(ErrorCodeResponseExample))]
         public async Task<IActionResult> Get(string token)
         {
             try
@@ -176,32 +187,18 @@ namespace Pirat.Controllers
         /// <summary>
         /// Creates an offer.
         /// </summary>
-        /// <remarks>
-        /// Sample request:
-        /// 
-        ///     POST /resources
-        ///     {
-        ///         "provider": {
-        ///             "address": {
-        ///                 "street": "Hauptstrasse",
-        ///                 "streetnumber": "1",
-        ///                 "postalcode": "80333",
-        ///                 "city": "München",
-        ///                 "country": "Deutschland",
-        ///                 "latitude": 0,
-        ///                 "longitude": 0
-        ///     }
-        /// </remarks>
         /// <param name="offer"></param>
         /// <returns>A newly created offer</returns>
         /// <response code="200">Returns the newly created offer</response>
         /// <response code="400">If data in the offer is invalid or not sufficient</response>
         [HttpPost]
-        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
-        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
         [Consumes("application/json")]
         [Produces("application/json")]
-        [SwaggerRequestExample(typeof(Offer), typeof(OfferModelExample))]
+        [SwaggerRequestExample(typeof(Offer), typeof(OfferRequestExample))]
+        [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(Offer))]
+        [SwaggerResponseExample(StatusCodes.Status200OK, typeof(OfferResponseExample))]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(ErrorCodeResponseExample))]
         public async Task<IActionResult> Post([FromBody] Offer offer)
         {
             try
@@ -224,13 +221,26 @@ namespace Pirat.Controllers
             }
         }
 
+        /// <summary>
+        /// Sending a demand request for the consumable with the given id to the non-public provider.
+        /// </summary>
+        /// <param name="contactInformationDemand"></param>
+        /// <param name="id">The id of the consumable</param>
+        /// <returns>Empty string</returns>
+        /// <response code="200">Empty string - consumable with provider found and mail has been sent</response>
+        /// <response code="404">Resource does not exist</response>
+        /// <response code="400">Invalid contact data</response>
         [HttpPost("consumables/{id:int}/contact")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(typeof(string), StatusCodes.Status404NotFound)]
-        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
         [Consumes("application/json")]
         [Produces("application/json")]
-        public async Task<IActionResult> ConsumableAnonymContact([FromBody] ContactInformationDemand contactInformationDemand, int id)
+        [SwaggerRequestExample(typeof(ContactInformationDemand), typeof(ContactInformationDemandExample))]
+        [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(EmptyResponseExample))]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(ErrorCodeResponseExample))]
+        [SwaggerResponse(StatusCodes.Status404NotFound, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status404NotFound, typeof(ErrorCodeResponseExample))]
+        public async Task<IActionResult> ConsumableAnonymousContact([FromBody] ContactInformationDemand contactInformationDemand, int id)
         {
             if (!_mailService.verifyMail(contactInformationDemand.senderEmail))
             {
@@ -254,12 +264,25 @@ namespace Pirat.Controllers
             return Ok();
         }
 
+        /// <summary>
+        /// Sending a demand request for the device with the given id to the non-public provider.
+        /// </summary>
+        /// <param name="contactInformationDemand"></param>
+        /// <param name="id">The id of the device</param>
+        /// <returns>Empty string</returns>
+        /// <response code="200">Empty string - consumable with provider found and mail has been sent</response>
+        /// <response code="404">Resource does not exist</response>
+        /// <response code="400">Invalid contact data</response>
         [HttpPost("devices/{id:int}/contact")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(typeof(string), StatusCodes.Status404NotFound)]
-        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
         [Consumes("application/json")]
         [Produces("application/json")]
+        [SwaggerRequestExample(typeof(ContactInformationDemand), typeof(ContactInformationDemandExample))]
+        [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(EmptyResponseExample))]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(ErrorCodeResponseExample))]
+        [SwaggerResponse(StatusCodes.Status404NotFound, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status404NotFound, typeof(ErrorCodeResponseExample))]
         public async Task<IActionResult> DeviceAnonymContact([FromBody] ContactInformationDemand contactInformationDemand, int id)
         {
             if (!_mailService.verifyMail(contactInformationDemand.senderEmail))
@@ -284,12 +307,25 @@ namespace Pirat.Controllers
             return Ok();
         }
 
+        /// <summary>
+        /// Sending a demand request for personal with the given id to the non-public provider.
+        /// </summary>
+        /// <param name="contactInformationDemand"></param>
+        /// <param name="id">The id of the personal</param>
+        /// <returns>Empty string</returns>
+        /// <response code="200">Empty string - personal with provider found and mail has been sent</response>
+        /// <response code="404">Resource does not exist</response>
+        /// <response code="400">Invalid contact data</response>
         [HttpPost("manpower/{id:int}/contact")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(typeof(string), StatusCodes.Status404NotFound)]
-        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
         [Consumes("application/json")]
         [Produces("application/json")]
+        [SwaggerRequestExample(typeof(ContactInformationDemand), typeof(ContactInformationDemandExample))]
+        [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(EmptyResponseExample))]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(ErrorCodeResponseExample))]
+        [SwaggerResponse(StatusCodes.Status404NotFound, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status404NotFound, typeof(ErrorCodeResponseExample))]
         public async Task<IActionResult> PersonalAnonymContact([FromBody] ContactInformationDemand contactInformationDemand, int id)
         {
             if (!_mailService.verifyMail(contactInformationDemand.senderEmail))
@@ -316,18 +352,32 @@ namespace Pirat.Controllers
 
 
         //***********DELETE REQUESTS
+        /// <summary>
+        /// Deletes the Offer that is assigned to the token.
+        /// </summary>
+        /// <param name="token">The token</param>
+        /// <returns>String</returns>
+        /// <response code="200">String - offer deleted</response>
+        /// <response code="404">Offer to token does not exist</response>
+        /// <response code="400">Invalid token</response>
+        /// <response code="500">Invalid data state</response>
         [HttpDelete("offers/{token}")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(typeof(string), StatusCodes.Status404NotFound)]
-        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(typeof(string), StatusCodes.Status500InternalServerError)]
         [Consumes("application/json")]
         [Produces("application/json")]
+        [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(EmptyResponseExample))]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(ErrorCodeResponseExample))]
+        [SwaggerResponse(StatusCodes.Status404NotFound, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status404NotFound, typeof(ErrorCodeResponseExample))]
+        [SwaggerResponse(StatusCodes.Status500InternalServerError, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status500InternalServerError, typeof(ErrorCodeResponseExample))]
         public async Task<IActionResult> Delete(string token)
         {
             try
             {
-                return Ok(await _demandService.delete(token));
+                await _demandService.delete(token);
+                return Ok();
             }
             catch (ArgumentException e)
             {

--- a/Pirat/Controllers/ResourceController.cs
+++ b/Pirat/Controllers/ResourceController.cs
@@ -117,7 +117,7 @@ namespace Pirat.Controllers
         }
 
         /// <summary>
-        /// Searches lift of Personals and the associated Provider. Provider only included if public.
+        /// Searches list of Personals and the associated Provider. Provider only included if public.
         /// </summary>
         /// <param name="manpower"></param>
         /// <param name="address"></param>
@@ -160,11 +160,12 @@ namespace Pirat.Controllers
         [HttpGet("offers/{token}")]
         [Consumes("application/json")]
         [Produces("application/json")]
-        [ProducesResponseType(typeof(Offer), StatusCodes.Status200OK)]
-        [ProducesResponseType(typeof(string), StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(Offer))]
+        [SwaggerResponseExample(StatusCodes.Status200OK, typeof(OfferResponseExample))]
         [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(string))]
         [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(ErrorCodeResponseExample))]
+        [SwaggerResponse(StatusCodes.Status404NotFound, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status404NotFound, typeof(ErrorCodeResponseExample))]
         public async Task<IActionResult> Get(string token)
         {
             try
@@ -235,7 +236,7 @@ namespace Pirat.Controllers
         [Produces("application/json")]
         [SwaggerRequestExample(typeof(ContactInformationDemand), typeof(ContactInformationDemandExample))]
         [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(string))]
-        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(EmptyResponseExample))]
+        [SwaggerResponseExample(StatusCodes.Status200OK, typeof(EmptyResponseExample))]
         [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(string))]
         [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(ErrorCodeResponseExample))]
         [SwaggerResponse(StatusCodes.Status404NotFound, Type = typeof(string))]
@@ -278,7 +279,7 @@ namespace Pirat.Controllers
         [Produces("application/json")]
         [SwaggerRequestExample(typeof(ContactInformationDemand), typeof(ContactInformationDemandExample))]
         [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(string))]
-        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(EmptyResponseExample))]
+        [SwaggerResponseExample(StatusCodes.Status200OK, typeof(EmptyResponseExample))]
         [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(string))]
         [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(ErrorCodeResponseExample))]
         [SwaggerResponse(StatusCodes.Status404NotFound, Type = typeof(string))]
@@ -321,7 +322,7 @@ namespace Pirat.Controllers
         [Produces("application/json")]
         [SwaggerRequestExample(typeof(ContactInformationDemand), typeof(ContactInformationDemandExample))]
         [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(string))]
-        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(EmptyResponseExample))]
+        [SwaggerResponseExample(StatusCodes.Status200OK, typeof(EmptyResponseExample))]
         [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(string))]
         [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(ErrorCodeResponseExample))]
         [SwaggerResponse(StatusCodes.Status404NotFound, Type = typeof(string))]
@@ -357,7 +358,7 @@ namespace Pirat.Controllers
         /// </summary>
         /// <param name="token">The token</param>
         /// <returns>String</returns>
-        /// <response code="200">String - offer deleted</response>
+        /// <response code="200">Empty - Offer deleted</response>
         /// <response code="404">Offer to token does not exist</response>
         /// <response code="400">Invalid token</response>
         /// <response code="500">Invalid data state</response>
@@ -365,7 +366,7 @@ namespace Pirat.Controllers
         [Consumes("application/json")]
         [Produces("application/json")]
         [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(string))]
-        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(EmptyResponseExample))]
+        [SwaggerResponseExample(StatusCodes.Status200OK, typeof(EmptyResponseExample))]
         [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(string))]
         [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(ErrorCodeResponseExample))]
         [SwaggerResponse(StatusCodes.Status404NotFound, Type = typeof(string))]

--- a/Pirat/Controllers/TelephoneCallbackController.cs
+++ b/Pirat/Controllers/TelephoneCallbackController.cs
@@ -4,8 +4,12 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Pirat.Codes;
+using Pirat.Extensions.Swagger.SwaggerConfiguration;
 using Pirat.Model;
 using Pirat.Services;
+using Swashbuckle.AspNetCore.Annotations;
+using Swashbuckle.AspNetCore.Filters;
 
 namespace Pirat.Controllers
 {
@@ -23,14 +27,17 @@ namespace Pirat.Controllers
 
 
         [HttpPost]
-        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        [Consumes("application/json")]
-        [Produces("application/json")]
+        [SwaggerRequestExample(typeof(TelephoneCallbackRequest), typeof(TelephoneCallbackRequestExample))]
+        [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(EmptyResponseExample))]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(string))]
+        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(ErrorCodeResponseExample))]
         public IActionResult Post([FromBody] TelephoneCallbackRequest telephoneCallbackRequest)
         {
+            if (!_mailService.verifyMail(telephoneCallbackRequest.email))
+            {
+                return BadRequest(Error.ErrorCodes.INVALID_MAIL);
+            }
             this._mailService.sendTelephoneCallbackMail(telephoneCallbackRequest);
             return Ok();
         }

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/ContactInformationDemandExample.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/ContactInformationDemandExample.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Pirat.Model;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Pirat.Extensions.Swagger.SwaggerConfiguration
+{
+    public class ContactInformationDemandExample : IExamplesProvider<object>
+    {
+        public object GetExamples()
+        {
+            return new ContactInformationDemand()
+            {
+                senderName = "Jack Sparrow",
+                senderEmail = "captainjacksparrow1@gmx.de",
+                senderPhone = "91919191",
+                senderInstitution = "Tortuga Pirates",
+                message = "Klar soweit?"
+            };
+        }
+    }
+}

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/EmptyResponseExample.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/EmptyResponseExample.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Pirat.Extensions.Swagger.SwaggerConfiguration
+{
+    public class EmptyResponseExample : IExamplesProvider<string>
+    {
+        public string GetExamples()
+        {
+            return "";
+        }
+    }
+}

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/ErrorCodeResponseExample.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/ErrorCodeResponseExample.cs
@@ -6,9 +6,9 @@ using Swashbuckle.AspNetCore.Filters;
 
 namespace Pirat.Extensions.Swagger.SwaggerConfiguration
 {
-    public class ErrorCodeResponseExample : IExamplesProvider<object>
+    public class ErrorCodeResponseExample : IExamplesProvider<string>
     {
-        public object GetExamples()
+        public string GetExamples()
         {
             return "XXXX:Description";
         }

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/ErrorCodeResponseExample.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/ErrorCodeResponseExample.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Pirat.Extensions.Swagger.SwaggerConfiguration
+{
+    public class ErrorCodeResponseExample : IExamplesProvider<object>
+    {
+        public object GetExamples()
+        {
+            return "XXXX:Description";
+        }
+    }
+}

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/OfferModelExample.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/OfferModelExample.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Pirat.Model;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Pirat.SwaggerConfiguration
+{
+    public class OfferModelExample : IExamplesProvider<object>
+    {
+        public object GetExamples()
+        {
+            return new Offer()
+            {
+                provider = new Provider()
+                {
+                    address = new Address()
+                    {
+                        street = "Hauptstraße",
+                        streetnumber = "77",
+                        postalcode = "27498",
+                        city = "Helgoland",
+                        country = "Deutschland",
+                    },
+                    name = "Störtebeker",
+                    organisation = "Instiut für Piraterie",
+                    phone = "987654",
+                    mail = "pirat.hilfsmittel@gmail.com",
+                    ispublic = true
+                },
+                personals = new List<Personal>()
+                {
+                    new Personal()
+                    {
+                        qualification = "Kapitän",
+                        area = "Schiffsfahrt, Piraterie",
+                        address = new Address()
+                        {
+                            street = "Hauptstraße",
+                            streetnumber = "77",
+                            postalcode = "27498",
+                            city = "Helgoland",
+                            country = "Deutschland"
+                        },
+                        institution = "Institut für Piraterie",
+                        researchgroup = "Piraten Ahoi",
+                        experience_rt_pcr = false,
+                        annotation = "Ahoi!"
+                    }
+                },
+                consumables = new List<Consumable>()
+                {
+                    new Consumable()
+                    {
+                        unit = "Liter",
+                        address = new Address()
+                        {
+                            street = "Hauptstraße",
+                            streetnumber = "77",
+                            postalcode = "27498",
+                            city = "Helgoland",
+                            country = "Deutschland"
+                        },
+                        category = "Rum",
+                        name = "Nordrum",
+                        manufacturer = "Störtebeker & Co",
+                        ordernumber = "999",
+                        amount = 100,
+                        annotation = "Arrr"
+                    }
+                },
+                devices = new List<Device>()
+                {
+                    new Device()
+                    {
+                        address = new Address()
+                        {
+                            street = "Hauptstraße",
+                            streetnumber = "77",
+                            postalcode = "27498",
+                            city = "Helgoland",
+                            country = "Deutschland"
+                        },
+                        category = "Schiffsmaterial",
+                        name = "Steuerrad",
+                        manufacturer = "Störtebeker & Co",
+                        ordernumber = "12345",
+                        amount = 10,
+                        annotation = "Volle Fahrt voraus!"
+                    }
+                }
+            };
+        }
+    }
+}

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/OfferRequestExample.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/OfferRequestExample.cs
@@ -7,7 +7,7 @@ using Swashbuckle.AspNetCore.Filters;
 
 namespace Pirat.SwaggerConfiguration
 {
-    public class OfferModelExample : IExamplesProvider<object>
+    public class OfferRequestExample : IExamplesProvider<object>
     {
         public object GetExamples()
         {

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/OfferResourceResponseExample.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/OfferResourceResponseExample.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Pirat.Model;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Pirat.Extensions.Swagger.SwaggerConfiguration
+{
+    public class OfferConsumableResponseExample : IExamplesProvider<object>
+    {
+        public object GetExamples()
+        {
+            return new OfferResource<List<Consumable>>()
+            {
+                provider = new Provider()
+                {
+                    address = new Address()
+                    {
+                        street = "Hauptstraße",
+                        streetnumber = "77",
+                        postalcode = "27498",
+                        city = "Helgoland",
+                        country = "Deutschland",
+                    },
+                    name = "Störtebeker",
+                    organisation = "Instiut für Piraterie",
+                    phone = "987654",
+                    mail = "pirat.hilfsmittel@gmail.com",
+                    ispublic = true
+                },
+                resource = new List<Consumable>()
+                {
+                    new Consumable()
+                    {
+                        unit = "Liter",
+                        address = new Address()
+                        {
+                            street = "Hauptstraße",
+                            streetnumber = "77",
+                            postalcode = "27498",
+                            city = "Helgoland",
+                            country = "Deutschland"
+                        },
+                        category = "Rum",
+                        name = "Nordrum",
+                        manufacturer = "Störtebeker & Co",
+                        ordernumber = "999",
+                        amount = 100,
+                        annotation = "Arrr",
+                        id = 99999999
+                    }
+                }
+            };
+        }
+    }
+
+    public class OfferDeviceResponseExample : IExamplesProvider<object>
+    {
+        public object GetExamples()
+        {
+            return new OfferResource<List<Device>>()
+            {
+                provider = new Provider()
+                {
+                    address = new Address()
+                    {
+                        street = "Hauptstraße",
+                        streetnumber = "77",
+                        postalcode = "27498",
+                        city = "Helgoland",
+                        country = "Deutschland",
+                    },
+                    name = "Störtebeker",
+                    organisation = "Instiut für Piraterie",
+                    phone = "987654",
+                    mail = "pirat.hilfsmittel@gmail.com",
+                    ispublic = true
+                },
+                resource = new List<Device>()
+                {
+                    new Device()
+                    {
+                        address = new Address()
+                        {
+                            street = "Hauptstraße",
+                            streetnumber = "77",
+                            postalcode = "27498",
+                            city = "Helgoland",
+                            country = "Deutschland"
+                        },
+                        category = "Schiffsmaterial",
+                        name = "Steuerrad",
+                        manufacturer = "Störtebeker & Co",
+                        ordernumber = "12345",
+                        amount = 10,
+                        annotation = "Volle Fahrt voraus!",
+                        id = 99999999
+                    }
+                }
+            };
+        }
+    }
+
+    public class OfferPersonalResponseExample : IExamplesProvider<object>
+    {
+        public object GetExamples()
+        {
+            return new OfferResource<List<Personal>>()
+            {
+                provider = new Provider()
+                {
+                    address = new Address()
+                    {
+                        street = "Hauptstraße",
+                        streetnumber = "77",
+                        postalcode = "27498",
+                        city = "Helgoland",
+                        country = "Deutschland",
+                    },
+                    name = "Störtebeker",
+                    organisation = "Instiut für Piraterie",
+                    phone = "987654",
+                    mail = "pirat.hilfsmittel@gmail.com",
+                    ispublic = true
+                },
+                resource = new List<Personal>()
+                {
+                    new Personal()
+                    {
+                        qualification = "Kapitän",
+                        area = "Schiffsfahrt, Piraterie",
+                        address = new Address()
+                        {
+                            street = "Hauptstraße",
+                            streetnumber = "77",
+                            postalcode = "27498",
+                            city = "Helgoland",
+                            country = "Deutschland"
+                        },
+                        institution = "Institut für Piraterie",
+                        researchgroup = "Piraten Ahoi",
+                        experience_rt_pcr = false,
+                        annotation = "Ahoi!",
+                        id = 99999999
+                    }
+                }
+
+            };
+
+        }
+    }
+}
+    

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/OfferResourceResponseExample.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/OfferResourceResponseExample.cs
@@ -7,9 +7,9 @@ using Swashbuckle.AspNetCore.Filters;
 
 namespace Pirat.Extensions.Swagger.SwaggerConfiguration
 {
-    public class OfferConsumableResponseExample : IExamplesProvider<object>
+    public class OfferConsumableResponseExample : IExamplesProvider<OfferResource<List<Consumable>>>
     {
-        public object GetExamples()
+        public OfferResource<List<Consumable>> GetExamples()
         {
             return new OfferResource<List<Consumable>>()
             {

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/OfferResponseExample.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/OfferResponseExample.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Pirat.Model;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Pirat.Extensions.Swagger.SwaggerConfiguration
+{
+    public class OfferResponseExample : IExamplesProvider<Offer>
+    {
+        public Offer GetExamples()
+        {
+            return new Offer()
+            {
+                provider = new Provider()
+                {
+                    address = new Address()
+                    {
+                        street = "Hauptstraße",
+                        streetnumber = "77",
+                        postalcode = "27498",
+                        city = "Helgoland",
+                        country = "Deutschland",
+                    },
+                    name = "Störtebeker",
+                    organisation = "Instiut für Piraterie",
+                    phone = "987654",
+                    mail = "pirat.hilfsmittel@gmail.com",
+                    ispublic = true
+                },
+                personals = new List<Personal>()
+                {
+                    new Personal()
+                    {
+                        qualification = "Kapitän",
+                        area = "Schiffsfahrt, Piraterie",
+                        address = new Address()
+                        {
+                            street = "Hauptstraße",
+                            streetnumber = "77",
+                            postalcode = "27498",
+                            city = "Helgoland",
+                            country = "Deutschland"
+                        },
+                        institution = "Institut für Piraterie",
+                        researchgroup = "Piraten Ahoi",
+                        experience_rt_pcr = false,
+                        annotation = "Ahoi!",
+                        id = 99999999
+                    }
+                },
+                consumables = new List<Consumable>()
+                {
+                    new Consumable()
+                    {
+                        unit = "Liter",
+                        address = new Address()
+                        {
+                            street = "Hauptstraße",
+                            streetnumber = "77",
+                            postalcode = "27498",
+                            city = "Helgoland",
+                            country = "Deutschland"
+                        },
+                        category = "Rum",
+                        name = "Nordrum",
+                        manufacturer = "Störtebeker & Co",
+                        ordernumber = "999",
+                        amount = 100,
+                        annotation = "Arrr",
+                        id = 99999999
+                    }
+                },
+                devices = new List<Device>()
+                {
+                    new Device()
+                    {
+                        address = new Address()
+                        {
+                            street = "Hauptstraße",
+                            streetnumber = "77",
+                            postalcode = "27498",
+                            city = "Helgoland",
+                            country = "Deutschland"
+                        },
+                        category = "Schiffsmaterial",
+                        name = "Steuerrad",
+                        manufacturer = "Störtebeker & Co",
+                        ordernumber = "12345",
+                        amount = 10,
+                        annotation = "Volle Fahrt voraus!",
+                        id = 99999999
+                    }
+                }
+            };
+        }
+    }
+}

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/SwaggerExcludeFilter.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/SwaggerExcludeFilter.cs
@@ -9,13 +9,13 @@ using System.Threading.Tasks;
 
 namespace Pirat.Helper
 {
-    public class SwaggerJsonIgnore : IOperationFilter
+    public class SwaggerExcludeFilter : IOperationFilter
     {
         public void Apply(OpenApiOperation operation, OperationFilterContext context)
         {
             var ignoredProperties = context.MethodInfo.GetParameters()
                 .SelectMany(p => p.ParameterType.GetProperties()
-                                 .Where(prop => prop.GetCustomAttribute<JsonIgnoreAttribute>() != null)
+                                 .Where(prop => prop.GetCustomAttribute<SwaggerExclude>() != null)
                                  );
             if (ignoredProperties.Any())
             {
@@ -28,5 +28,8 @@ namespace Pirat.Helper
 
             }
         }
+
+        [AttributeUsage(AttributeTargets.Property)]
+        public class SwaggerExclude : Attribute { }
     }
 }

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/TelephoneCallbackRequestExample.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/TelephoneCallbackRequestExample.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Pirat.Model;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Pirat.Extensions.Swagger.SwaggerConfiguration
+{
+    public class TelephoneCallbackRequestExample : IExamplesProvider<object>
+    {
+        public object GetExamples()
+        {
+            return new TelephoneCallbackRequest()
+            {
+                name = "Jack Sparrow",
+                email = "captainjacksparrow1@gmx.de",
+                phone = "91919191",
+                topic = "Port Royal",
+                notes = "Was haltet ihr von drei Schilling und wir vergessen den Namen."
+            };
+        }
+    }
+}

--- a/Pirat/Extensions/Swagger/SwaggerConfigurationExtensions.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfigurationExtensions.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
+using Pirat.Extensions.Swagger.SwaggerConfiguration;
 using Pirat.Helper;
 using Pirat.SwaggerConfiguration;
 using Swashbuckle.AspNetCore.Filters;
@@ -17,8 +18,12 @@ namespace Pirat.Extensions.Swagger
         public static void AddSwagger(this IServiceCollection services)
         {
 
-            services.AddSwaggerExamplesFromAssemblyOf<OfferModelExample>();
-            //Add more examples here for swagger
+            services.AddSwaggerExamplesFromAssemblyOf<OfferResponseExample>();
+            services.AddSwaggerExamplesFromAssemblyOf<OfferRequestExample>();
+            
+            services.AddSwaggerExamplesFromAssemblyOf<ErrorCodeResponseExample>();
+            //Add more examples here for swagger response and swagger request
+
 
             services.AddSwaggerGen(c =>
             {

--- a/Pirat/Extensions/Swagger/SwaggerConfigurationExtensions.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfigurationExtensions.cs
@@ -20,8 +20,8 @@ namespace Pirat.Extensions.Swagger
 
             services.AddSwaggerExamplesFromAssemblyOf<OfferResponseExample>();
             services.AddSwaggerExamplesFromAssemblyOf<OfferRequestExample>();
-            
             services.AddSwaggerExamplesFromAssemblyOf<ErrorCodeResponseExample>();
+            services.AddSwaggerExamplesFromAssemblyOf<OfferConsumableResponseExample>();
             //Add more examples here for swagger response and swagger request
 
 

--- a/Pirat/Extensions/Swagger/SwaggerConfigurationExtensions.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfigurationExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+using Pirat.Helper;
+using Pirat.SwaggerConfiguration;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Pirat.Extensions.Swagger
+{
+    public static class SwaggerConfigurationExtensions
+    {
+        public static void AddSwagger(this IServiceCollection services)
+        {
+
+            services.AddSwaggerExamplesFromAssemblyOf<OfferModelExample>();
+            //Add more examples here for swagger
+
+            services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "PIRAT API", Version = "v1" });
+                c.OperationFilter<SwaggerExcludeFilter>();
+                c.ExampleFilters();
+
+                // Set the comments path for the Swagger JSON and UI.
+                var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+                var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
+                c.IncludeXmlComments(xmlPath);
+            });
+            
+        }
+    }
+}

--- a/Pirat/Model/Resource.cs
+++ b/Pirat/Model/Resource.cs
@@ -2,12 +2,16 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using Pirat.DatabaseContext;
+using Pirat.Helper;
 
 namespace Pirat.Model
 {
     public class Resource
     {
+        [JsonProperty]
+        [SwaggerExcludeFilter.SwaggerExclude]
         public int id { get; set; }
 
     }

--- a/Pirat/Pirat.csproj
+++ b/Pirat/Pirat.csproj
@@ -6,12 +6,14 @@
 
   <ItemGroup>
     <Folder Include="Configurations\" />
+    <Folder Include="Helper\" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="MailKit" Version="2.5.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="5.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.2.0" />
@@ -20,5 +22,10 @@
   <ItemGroup>
     <None Include="appsettings.prod.json" CopyToPublishDirectory="Always" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
 
 </Project>

--- a/Pirat/Pirat.csproj
+++ b/Pirat/Pirat.csproj
@@ -5,8 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Helper\**" />
+    <Content Remove="Helper\**" />
+    <EmbeddedResource Remove="Helper\**" />
+    <None Remove="Helper\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Folder Include="Configurations\" />
-    <Folder Include="Helper\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Pirat/Services/MailService.cs
+++ b/Pirat/Services/MailService.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Pirat.Model;
@@ -39,7 +40,18 @@ namespace Pirat.Services
 
         public bool verifyMail(string mailAddress)
         {
+            if (!verifyMailWithRegex(mailAddress))
+            {
+                return false;
+            }
             return MailboxAddress.TryParse(mailAddress, out _);
+        }
+
+        private bool verifyMailWithRegex(string mailAddress)
+        {
+            string pattern = @"^(?!\.)(""([^""\r\\]|\\[""\r\\])*""|" + @"([-a-z0-9!#$%&'*+/=?^_`{|}~]|(?<!\.)\.)*)(?<!\.)" + @"@[a-z0-9][\w\.-]*[a-z0-9]\.[a-z][a-z\.]*[a-z]$";
+            var regex = new Regex(pattern, RegexOptions.IgnoreCase);
+            return regex.IsMatch(mailAddress);
         }
 
         public async void sendDemandMailToProvider(ContactInformationDemand demandInformation, string mailAddressReceiver, string receiverMailUserName)

--- a/Pirat/Startup.cs
+++ b/Pirat/Startup.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -16,8 +18,11 @@ using Microsoft.OpenApi.Models;
 using Npgsql;
 using Pirat.DatabaseContext;
 using Pirat.Extensions;
+using Pirat.Extensions.Swagger;
 using Pirat.Helper;
 using Pirat.Services;
+using Pirat.SwaggerConfiguration;
+using Swashbuckle.AspNetCore.Filters;
 
 namespace Pirat
 {
@@ -65,12 +70,8 @@ namespace Pirat
             //DB context
             services.AddDbContext<DemandContext>(options => options.UseNpgsql(connectionString));
 
-            //Swagger
-            services.AddSwaggerGen(c =>
-            {
-                c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
-                c.OperationFilter<SwaggerJsonIgnore>();
-            });
+            //Swagger (see extensions)
+            services.AddSwagger(); 
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -103,8 +104,10 @@ namespace Pirat
 
             app.UseHealthChecks("/health");
 
-
-            app.UseReCapture();
+            if (env.IsProduction())
+            {
+                app.UseReCapture();
+            }
             app.UseAuthentication();
             app.UseAuthorization();
 


### PR DESCRIPTION
#43 

Eigener Filter SwaggerExclude um Parameter (die keine sind) in den GET Queries auszuschalten.

Benutzung von SwaggerRequestExample und SwaggerResponseExample, um eigene Default Examples für Swagger zu erstellen bzw. Beispiel Antworten zu sehen.

C# Doku kann in Swagger eingebunden werden.

Swagger Ordner für Konfiguration und Examples.