### PR TITLE
Delete resource

### DIFF
--- a/Pirat.DatabaseTests/ResourceDeleteTest.cs
+++ b/Pirat.DatabaseTests/ResourceDeleteTest.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Pirat.DatabaseContext;
+using Pirat.DatabaseTests.Examples;
+using Pirat.Examples.TestExamples;
+using Pirat.Model;
+using Pirat.Services;
+using Pirat.Services.Resource;
+
+namespace Pirat.DatabaseTests
+{
+    public class ResourceDeleteTest
+    {
+
+        private const string connectionString =
+            "Server=localhost;Port=5432;Database=postgres;User ID=postgres;Password=postgres";
+
+        private static DbContextOptions<DemandContext> options =
+            new DbContextOptionsBuilder<DemandContext>().UseNpgsql(connectionString).Options;
+
+        private static readonly DemandContext DemandContext = new DemandContext(options);
+
+        private readonly ResourceDemandService _resourceDemandService;
+
+        private readonly ResourceUpdateService _resourceUpdateService;
+
+        private readonly CaptainHookGenerator _captainHookGenerator;
+
+        private readonly AnneBonnyGenerator _anneBonnyGenerator;
+
+        private readonly Offer _offerCaptainHook;
+
+        private readonly string _tokenCaptainHook;
+
+        private readonly Offer _offerAnneBonny;
+
+        private readonly string _tokenAnneBonny;
+
+        public ResourceDeleteTest()
+        {
+            var loggerDemand = new Mock<ILogger<ResourceDemandService>>();
+            var loggerUpdate = new Mock<ILogger<ResourceUpdateService>>();
+            var addressMaker = new Mock<IAddressMaker>();
+            addressMaker.Setup(m => m.SetCoordinates(It.IsAny<AddressEntity>())).Callback((AddressEntity a) =>
+            {
+                a.latitude = 0;
+                a.longitude = 0;
+                a.hascoordinates = false;
+            });
+
+            this._resourceDemandService = new ResourceDemandService(loggerDemand.Object, DemandContext, addressMaker.Object);
+            _resourceUpdateService = new ResourceUpdateService(loggerUpdate.Object, DemandContext, addressMaker.Object);
+            _captainHookGenerator = new CaptainHookGenerator();
+            _anneBonnyGenerator = new AnneBonnyGenerator();
+
+            var task = Task.Run(async () =>
+            {
+                Offer offer = _captainHookGenerator.generateOffer();
+                var token = await _resourceUpdateService.insert(offer);
+                offer = await _resourceDemandService.queryLink(token);
+                return (offer, token);
+            });
+            task.Wait();
+            (_offerCaptainHook, _tokenCaptainHook) = task.Result;
+
+            task = Task.Run(async () =>
+            {
+                Offer offer = _anneBonnyGenerator.generateOffer();
+                var token = await _resourceUpdateService.insert(offer);
+                offer = await _resourceDemandService.queryLink(token);
+                return (offer, token);
+            });
+            task.Wait();
+            (_offerAnneBonny, _tokenAnneBonny) = task.Result;
+        }
+    }
+}

--- a/Pirat.DatabaseTests/ResourceDeleteTest.cs
+++ b/Pirat.DatabaseTests/ResourceDeleteTest.cs
@@ -97,6 +97,9 @@ namespace Pirat.DatabaseTests
             Assert.Null(exception);
         }
 
+        /// <summary>
+        /// Tests marking of a consumable as deleted and tests that this personal is not retrieved anymore
+        /// </summary>
         public async void Test_DeleteConsumable()
         {
             var consumableCh = _offerCaptainHook.consumables[0];
@@ -126,6 +129,9 @@ namespace Pirat.DatabaseTests
             Assert.NotEmpty(foundOfferAb.consumables);
         }
 
+        /// <summary>
+        /// Tests marking of a device as deleted and tests that this device is not retrieved anymore
+        /// </summary>
         public async void Test_DeleteDevice()
         {
             var deviceCh = _offerCaptainHook.devices[0];
@@ -155,6 +161,9 @@ namespace Pirat.DatabaseTests
             Assert.NotEmpty(foundOfferAb.devices);
         }
 
+        /// <summary>
+        /// Tests marking of a personal as deleted and tests that this personal is not retrieved anymore
+        /// </summary>
         public async void Test_DeletePersonal()
         {
             var personalCh = _offerCaptainHook.personals[0];
@@ -184,6 +193,9 @@ namespace Pirat.DatabaseTests
             Assert.NotEmpty(foundOfferAb.personals);
         }
 
+        /// <summary>
+        /// Tests and compare the different behaviour of query methods in <see cref="ResourceDemandService"/>
+        /// </summary>
         public async void Test_DeleteDevice_CompareQueryMethods()
         {
             var device = _offerCaptainHook.devices[0];
@@ -207,6 +219,9 @@ namespace Pirat.DatabaseTests
             Assert.NotNull(foundDevice);
         }
 
+        /// <summary>
+        /// Tests that deleting resources without a reason is not possible
+        /// </summary>
         public async void Test_DeleteResourceWithoutReason_NotPossible()
         {
             await Assert.ThrowsAsync<ArgumentException>(() => _resourceUpdateService.MarkConsumableAsDeleted(_tokenAnneBonny, _offerAnneBonny.consumables[0].id, ""));
@@ -216,6 +231,9 @@ namespace Pirat.DatabaseTests
             await Assert.ThrowsAsync<ArgumentException>(() => _resourceUpdateService.MarkPersonalAsDeleted(_tokenAnneBonny, _offerAnneBonny.personals[0].id, ""));
         }
 
+        /// <summary>
+        /// Tests that deleting of non-existing resources throws an exception when try to delete them
+        /// </summary>
         public async void Test_DeleteNonExistingResource_NotPossible()
         {
             await Assert.ThrowsAsync<DataNotFoundException>(() => _resourceUpdateService.MarkConsumableAsDeleted(_tokenAnneBonny, 999999, ""));

--- a/Pirat.DatabaseTests/ResourceDeleteTest.cs
+++ b/Pirat.DatabaseTests/ResourceDeleteTest.cs
@@ -118,12 +118,35 @@ namespace Pirat.DatabaseTests
             //Finding the device of captain hook not possible anymore
             foundOfferCh = await _resourceDemandService.queryLink(_tokenCaptainHook);
             Assert.NotNull(foundOfferCh);
-            Assert.Empty(foundOfferCh.consumables);
+            Assert.Empty(foundOfferCh.devices);
 
             //Finding device of anne bonny still possible
             foundOfferAb = await _resourceDemandService.queryLink(_tokenAnneBonny);
             Assert.NotNull(foundOfferAb);
-            Assert.NotEmpty(foundOfferAb.consumables);
+            Assert.NotEmpty(foundOfferAb.devices);
+        }
+
+        public async void Test_DeleteDevice_CompareQueryMethods()
+        {
+            var device = _offerCaptainHook.devices[0];
+
+            //Mark as deleted
+            await _resourceUpdateService.MarkDeviceAsDeleted(_tokenCaptainHook, device.id, "A reason");
+
+            //Device should not be retrieved by querying the link
+            var foundOffer = await _resourceDemandService.queryLink(_tokenCaptainHook);
+            Assert.NotNull(foundOffer);
+            Assert.Empty(foundOffer.devices);
+
+            //Device should not be retrieved by querying with a device object
+            var deviceForQuery = _captainHookGenerator.GenerateDevice();
+            var foundDevices = await _resourceDemandService.QueryOffers(deviceForQuery);
+            Assert.NotNull(foundDevices);
+            Assert.Empty(foundDevices);
+
+            //Find method should return the device nevertheless
+            var foundDevice = await _resourceDemandService.Find(new DeviceEntity(), device.id);
+            Assert.NotNull(foundDevice);
         }
     }
 }

--- a/Pirat/Codes/Error.cs
+++ b/Pirat/Codes/Error.cs
@@ -51,6 +51,7 @@
 
             public const string MORE_THAN_ONE_OFFER_FROM_TOKEN = "9000:MoreThanOneOfferFromToken";
             public const string UPDATES_MADE_IN_TOO_MANY_ROWS = "9001:UpdatesMadeInTooManyRows";
+            public const string RESOURCE_WITHOUT_RELATED_ADDRESS = "9002:ResourceWithoutRelatedAddress";
 
         }
     }

--- a/Pirat/Controllers/ResourceController.cs
+++ b/Pirat/Controllers/ResourceController.cs
@@ -611,11 +611,11 @@ namespace Pirat.Controllers
         [HttpDelete("offers/{token}/consumable/{id:int}")]
         [Consumes("application/json")]
         [Produces("application/json")]
-        public async Task<IActionResult> DeleteConsumable(string token, int id, [FromBody] string reason)
+        public async Task<IActionResult> MarkConsumableAsDeleted(string token, int id, [FromBody] string reason)
         {
             try
             {
-                await _resourceUpdateService.DeleteConsumable(token, id, reason);
+                await _resourceUpdateService.MarkConsumableAsDeleted(token, id, reason);
                 return Ok();
             }
             catch (ArgumentException e)
@@ -635,11 +635,11 @@ namespace Pirat.Controllers
         [HttpDelete("offers/{token}/device/{id:int}")]
         [Consumes("application/json")]
         [Produces("application/json")]
-        public async Task<IActionResult> DeleteDevice(string token, int id, [FromBody] string reason)
+        public async Task<IActionResult> MarkDeviceAsDeleted(string token, int id, [FromBody] string reason)
         {
             try
             {
-                await _resourceUpdateService.DeleteDevice(token, id, reason);
+                await _resourceUpdateService.MarkDeviceAsDeleted(token, id, reason);
                 return Ok();
             }
             catch (ArgumentException e)
@@ -659,11 +659,11 @@ namespace Pirat.Controllers
         [HttpDelete("offers/{token}/personal/{id:int}")]
         [Consumes("application/json")]
         [Produces("application/json")]
-        public async Task<IActionResult> DeletePersonal(string token, int id, [FromBody] string reason)
+        public async Task<IActionResult> MarkPersonalAsDeleted(string token, int id, [FromBody] string reason)
         {
             try
             {
-                await _resourceUpdateService.DeletePersonal(token, id, reason);
+                await _resourceUpdateService.MarkPersonalAsDeleted(token, id, reason);
                 return Ok();
             }
             catch (ArgumentException e)

--- a/Pirat/Controllers/ResourceController.cs
+++ b/Pirat/Controllers/ResourceController.cs
@@ -608,5 +608,73 @@ namespace Pirat.Controllers
             }
         }
 
+        [HttpDelete("offers/{token}/consumable/{id:int}")]
+        [Consumes("application/json")]
+        [Produces("application/json")]
+        public async Task<IActionResult> DeleteConsumable(string token, int id, [FromBody] string reason)
+        {
+            try
+            {
+                await _resourceUpdateService.DeleteConsumable(token, id, reason);
+                return Ok();
+            }
+            catch (ArgumentException e)
+            {
+                return BadRequest(e.Message);
+            }
+            catch (DataNotFoundException e)
+            {
+                return NotFound(e.Message);
+            }
+            catch (InvalidDataStateException e)
+            {
+                return StatusCode(StatusCodes.Status500InternalServerError, e);
+            }
+        }
+
+        [HttpDelete("offers/{token}/device/{id:int}")]
+        [Consumes("application/json")]
+        [Produces("application/json")]
+        public async Task<IActionResult> DeleteDevice(string token, int id, [FromBody] string reason)
+        {
+            try
+            {
+                await _resourceUpdateService.DeleteDevice(token, id, reason);
+                return Ok();
+            }
+            catch (ArgumentException e)
+            {
+                return BadRequest(e.Message);
+            }
+            catch (DataNotFoundException e)
+            {
+                return NotFound(e.Message);
+            }
+            catch (InvalidDataStateException e)
+            {
+                return StatusCode(StatusCodes.Status500InternalServerError, e);
+            }
+        }
+
+        [HttpDelete("offers/{token}/personal/{id:int}")]
+        [Consumes("application/json")]
+        [Produces("application/json")]
+        public async Task<IActionResult> DeletePersonal(string token, int id, [FromBody] string reason)
+        {
+            try
+            {
+                await _resourceUpdateService.DeletePersonal(token, id, reason);
+                return Ok();
+            }
+            catch (ArgumentException e)
+            {
+                return BadRequest(e.Message);
+            }
+            catch (DataNotFoundException e)
+            {
+                return NotFound(e.Message);
+            }
+        }
+
     }
 }

--- a/Pirat/DatabaseContext/DemandContext.cs
+++ b/Pirat/DatabaseContext/DemandContext.cs
@@ -22,7 +22,7 @@ namespace Pirat.DatabaseContext
 
         public DbSet<RegionSubscription> region_subscription { get; set; }
         
-        public DbSet<Change> change { get; set; }
+        public DbSet<ChangeEntity> change { get; set; }
 
         public DemandContext(DbContextOptions<DemandContext> options) : base(options)
         {

--- a/Pirat/Model/Entity/AddressEntity.cs
+++ b/Pirat/Model/Entity/AddressEntity.cs
@@ -15,7 +15,9 @@ namespace Pirat.Model
 
 		public int id { get; set; }
 
-		public bool hascoordinates { get; set; } = false;
+		public bool hascoordinates { get; set; }
+
+        public bool is_deleted { get; set; }
 
 		public AddressEntity build(Address a)
 		{
@@ -39,6 +41,7 @@ namespace Pirat.Model
             latitude = other.latitude;
             longitude = other.longitude;
             hascoordinates = other.hascoordinates;
+            is_deleted = other.is_deleted;
         }
 
 		public override string ToString()

--- a/Pirat/Model/Entity/ChangeEntity.cs
+++ b/Pirat/Model/Entity/ChangeEntity.cs
@@ -4,7 +4,7 @@ using Pirat.Model.Entity;
 
 namespace Pirat.Model
 {
-    public class Change: Insertable
+    public class ChangeEntity: Insertable
     {
         public int id { get; set; }
         
@@ -24,5 +24,21 @@ namespace Pirat.Model
             context.SaveChanges();
             return this;
         }
+
+        public static class ElementType
+        {
+            public static string Device = "device";
+            public static string Consumable = "consumable";
+            public static string Personal = "personal";
+        }
+
+        public static class ChangeType
+        {
+            public static string IncreaseAmount = "INCREASE_AMOUNT";
+            public static string DecreaseAmount = "DECREASE_AMOUNT";
+            public static string DeleteResource = "DELETE_RESOURCE";
+        }
+
     }
+
 }

--- a/Pirat/Model/Entity/ItemEntity.cs
+++ b/Pirat/Model/Entity/ItemEntity.cs
@@ -11,6 +11,8 @@ namespace Pirat.Model.Entity
         public int offer_id { get; set; }
 
         public int address_id { get; set; }
+
+        public bool is_deleted { get; set; }
     }
 
 }

--- a/Pirat/Model/Entity/PersonalEntity.cs
+++ b/Pirat/Model/Entity/PersonalEntity.cs
@@ -19,6 +19,8 @@ namespace Pirat.Model.Entity
 
         public string area { get; set; }
 
+        public bool is_deleted { get; set; }
+
         public PersonalEntity build(Personal p)
         {
             institution = p.institution;

--- a/Pirat/Services/Resource/IResourceDemandService.cs
+++ b/Pirat/Services/Resource/IResourceDemandService.cs
@@ -15,6 +15,15 @@ namespace Pirat.Services.Resource
 
         public Task<List<OfferResource<Personal>>> QueryOffers(Manpower manpower);
 
+        /// <summary>
+        /// Finds an entity that implements <see cref="Findable"/> by the given ID. Calling this method during runtime, findable is always an entity object implementing
+        /// Findable. The object attributes are more or less unimportant and it has the only purpose to determine in which table of the database the search is made since <c>Find</c> calls the implementation
+        /// of the find method in the class of the object. If a row exists to the given ID the corresponding entity is retrieved. Note that this method always
+        /// returns the entity if it exists.
+        /// </summary>
+        /// <param name="findable"></param>
+        /// <param name="id">The id to find the entity in the database</param>
+        /// <returns>The found entity as Findable</returns>
         public Task<Findable> Find(Findable findable, int id);
 
         public Task<Offer> queryLink(string token);

--- a/Pirat/Services/Resource/IResourceUpdateService.cs
+++ b/Pirat/Services/Resource/IResourceUpdateService.cs
@@ -66,5 +66,11 @@ namespace Pirat.Services.Resource
         public Task AddResource(string token, Device device);
         
         public Task AddResource(string token, Personal personal);
+
+        public Task DeleteConsumable(string token, int consumableId, string reason);
+
+        public Task DeleteDevice(string token, int deviceId, string reason);
+
+        public Task DeletePersonal(string token,int personalId, string reason);
     }
 }

--- a/Pirat/Services/Resource/IResourceUpdateService.cs
+++ b/Pirat/Services/Resource/IResourceUpdateService.cs
@@ -67,10 +67,10 @@ namespace Pirat.Services.Resource
         
         public Task AddResource(string token, Personal personal);
 
-        public Task DeleteConsumable(string token, int consumableId, string reason);
+        public Task MarkConsumableAsDeleted(string token, int consumableId, string reason);
 
-        public Task DeleteDevice(string token, int deviceId, string reason);
+        public Task MarkDeviceAsDeleted(string token, int deviceId, string reason);
 
-        public Task DeletePersonal(string token,int personalId, string reason);
+        public Task MarkPersonalAsDeleted(string token,int personalId, string reason);
     }
 }

--- a/Pirat/Services/Resource/IResourceUpdateService.cs
+++ b/Pirat/Services/Resource/IResourceUpdateService.cs
@@ -67,10 +67,31 @@ namespace Pirat.Services.Resource
         
         public Task AddResource(string token, Personal personal);
 
+        /// <summary>
+        /// Marks the consumable which is retrieved by the given token and consumable id as deleted.
+        /// </summary>
+        /// <param name="token">The unique token</param>
+        /// <param name="consumableId">The unique consumable id</param>
+        /// <param name="reason">The reason from the client. Must be non-empty.</param>
+        /// <returns></returns>
         public Task MarkConsumableAsDeleted(string token, int consumableId, string reason);
 
+        /// <summary>
+        /// Marks the device which is retrieved by the given token and device id as deleted.
+        /// </summary>
+        /// <param name="token">The unique token</param>
+        /// <param name="deviceId">The unique device id</param>
+        /// <param name="reason">The reason from the client. Must be non-empty.</param>
+        /// <returns></returns>
         public Task MarkDeviceAsDeleted(string token, int deviceId, string reason);
 
+        /// <summary>
+        /// Marks the personal which is retrieved by the given token and personal id as deleted.
+        /// </summary>
+        /// <param name="token">The unique token</param>
+        /// <param name="personalId">The unique personal id</param>
+        /// <param name="reason">The reason from the client. Must be non-empty.</param>
+        /// <returns></returns>
         public Task MarkPersonalAsDeleted(string token,int personalId, string reason);
     }
 }

--- a/Pirat/Services/Resource/ResourceDemandService.cs
+++ b/Pirat/Services/Resource/ResourceDemandService.cs
@@ -44,7 +44,7 @@ namespace Pirat.Services.Resource
                         join c in _context.consumable on o.id equals c.offer_id
                         join ap in _context.address on o.address_id equals ap.id
                         join ac in _context.address on c.address_id equals ac.id
-                        where consumable.category.Equals(c.category)
+                        where consumable.category.Equals(c.category) && !c.is_deleted
                         select new { o, c, ap, ac };
 
             if (!string.IsNullOrEmpty(consumable.name))
@@ -115,7 +115,7 @@ namespace Pirat.Services.Resource
                         join d in _context.device on o.id equals d.offer_id
                         join ap in _context.address on o.address_id equals ap.id
                         join ac in _context.address on d.address_id equals ac.id
-                        where device.category.Equals(d.category)
+                        where device.category.Equals(d.category) && !d.is_deleted
                         select new { o, d, ap, ac };
 
             if (!string.IsNullOrEmpty(device.name))
@@ -184,6 +184,7 @@ namespace Pirat.Services.Resource
                         join personal in _context.personal on o.id equals personal.offer_id
                         join ap in _context.address on o.address_id equals ap.id
                         join ac in _context.address on personal.address_id equals ac.id
+                        where !personal.is_deleted
                         select new { o, personal, ap, ac };
 
             if (!string.IsNullOrEmpty(manpower.institution))
@@ -273,6 +274,7 @@ namespace Pirat.Services.Resource
             List<ConsumableEntity> consumableEntities = queC.Select(c => c).ToList();
             foreach (ConsumableEntity c in consumableEntities)
             {
+                if (c.is_deleted) continue;
                 offer.consumables.Add(new Consumable().build(c).build(_queryHelper.queryAddress(c.address_id)));
             }
 
@@ -280,6 +282,7 @@ namespace Pirat.Services.Resource
             List<DeviceEntity> deviceEntities = queD.Select(d => d).ToList();
             foreach (DeviceEntity d in deviceEntities)
             {
+                if(d.is_deleted) continue;
                 offer.devices.Add(new Device().build(d).build(_queryHelper.queryAddress(d.address_id)));
             }
 
@@ -287,6 +290,7 @@ namespace Pirat.Services.Resource
             List<PersonalEntity> personalEntities = queP.Select(p => p).ToList();
             foreach (PersonalEntity p in personalEntities)
             {
+                if(p.is_deleted) continue;
                 offer.personals.Add(new Personal().build(p).build(_queryHelper.queryAddress(p.address_id)));
             }
 

--- a/Pirat/Services/Resource/ResourceUpdateService.cs
+++ b/Pirat/Services/Resource/ResourceUpdateService.cs
@@ -405,7 +405,7 @@ namespace Pirat.Services.Resource
             throw new NotImplementedException();
         }
 
-        public async Task DeleteConsumable(string token, int consumableId, string reason)
+        public async Task MarkConsumableAsDeleted(string token, int consumableId, string reason)
         {
             if (reason.Trim().Length == 0)
             {
@@ -441,7 +441,7 @@ namespace Pirat.Services.Resource
             }.Insert(_context);
         }
 
-        public async Task DeleteDevice(string token, int deviceId, string reason)
+        public async Task MarkDeviceAsDeleted(string token, int deviceId, string reason)
         {
             if (reason.Trim().Length == 0)
             {
@@ -476,7 +476,7 @@ namespace Pirat.Services.Resource
             }.Insert(_context);
         }
 
-        public async Task DeletePersonal(string token, int personalId, string reason)
+        public async Task MarkPersonalAsDeleted(string token, int personalId, string reason)
         {
             if (reason.Trim().Length == 0)
             {

--- a/Pirat/Services/Resource/ResourceUpdateService.cs
+++ b/Pirat/Services/Resource/ResourceUpdateService.cs
@@ -287,7 +287,7 @@ namespace Pirat.Services.Resource
                 consumable.Update(_context);
                 
                 // Add log
-                new Change()
+                new ChangeEntity()
                 {
                     change_type = "INCREASE_AMOUNT",
                     element_id = consumable.id,
@@ -312,7 +312,7 @@ namespace Pirat.Services.Resource
             consumable.Update(_context);
             
             // Add log
-            new Change()
+            new ChangeEntity()
             {
                 change_type = "DECREASE_AMOUNT",
                 element_id = consumable.id,
@@ -355,7 +355,7 @@ namespace Pirat.Services.Resource
                 device.Update(_context);
                 
                 // Add log
-                new Change()
+                new ChangeEntity()
                 {
                     change_type = "INCREASE_AMOUNT",
                     element_id = device.id,
@@ -380,7 +380,7 @@ namespace Pirat.Services.Resource
             device.Update(_context);
             
             // Add log
-            new Change()
+            new ChangeEntity()
             {
                 change_type = "DECREASE_AMOUNT",
                 element_id = device.id,
@@ -403,6 +403,113 @@ namespace Pirat.Services.Resource
         public Task AddResource(string token, Personal personal)
         {
             throw new NotImplementedException();
+        }
+
+        public async Task DeleteConsumable(string token, int consumableId, string reason)
+        {
+            if (reason.Trim().Length == 0)
+            {
+                throw new ArgumentException(Error.ErrorCodes.INVALID_REASON);
+            }
+
+            ConsumableEntity consumableEntity = (ConsumableEntity) new ConsumableEntity().Find(_context, consumableId);
+            AddressEntity addressEntity = (AddressEntity)new AddressEntity().Find(_context, consumableEntity.address_id);
+
+
+            if (consumableEntity is null)
+            {
+                throw new DataNotFoundException(Error.ErrorCodes.NOTFOUND_CONSUMABLE);
+            }
+            if (addressEntity is null)
+            {
+                throw new InvalidDataStateException(Error.FatalCodes.RESOURCE_WITHOUT_RELATED_ADDRESS);
+            }
+
+            consumableEntity.is_deleted = true;
+            consumableEntity.Update(_context);
+
+            addressEntity.is_deleted = true;
+            addressEntity.Update(_context);
+
+            new ChangeEntity()
+            {
+                change_type = ChangeEntity.ChangeType.DeleteResource,
+                element_id = consumableEntity.id,
+                element_type = ChangeEntity.ElementType.Consumable,
+                reason = reason,
+                timestamp = DateTime.Now
+            }.Insert(_context);
+        }
+
+        public async Task DeleteDevice(string token, int deviceId, string reason)
+        {
+            if (reason.Trim().Length == 0)
+            {
+                throw new ArgumentException(Error.ErrorCodes.INVALID_REASON);
+            }
+
+            DeviceEntity deviceEntity = (DeviceEntity)new DeviceEntity().Find(_context, deviceId);
+            AddressEntity addressEntity = (AddressEntity)new AddressEntity().Find(_context, deviceEntity.address_id);
+
+            if (deviceEntity is null)
+            {
+                throw new DataNotFoundException(Error.ErrorCodes.NOTFOUND_DEVICE);
+            }
+            if (addressEntity is null)
+            {
+                throw new InvalidDataStateException(Error.FatalCodes.RESOURCE_WITHOUT_RELATED_ADDRESS);
+            }
+
+            deviceEntity.is_deleted = true;
+            deviceEntity.Update(_context);
+
+            addressEntity.is_deleted = true;
+            addressEntity.Update(_context);
+
+            new ChangeEntity()
+            {
+                change_type = ChangeEntity.ChangeType.DeleteResource,
+                element_id = deviceEntity.id,
+                element_type = ChangeEntity.ElementType.Device,
+                reason = reason,
+                timestamp = DateTime.Now
+            }.Insert(_context);
+        }
+
+        public async Task DeletePersonal(string token, int personalId, string reason)
+        {
+            if (reason.Trim().Length == 0)
+            {
+                throw new ArgumentException(Error.ErrorCodes.INVALID_REASON);
+            }
+
+            PersonalEntity personalEntity = (PersonalEntity)new PersonalEntity().Find(_context, personalId);
+            AddressEntity addressEntity = (AddressEntity) new AddressEntity().Find(_context, personalEntity.address_id);
+
+            if (personalEntity is null)
+            {
+                throw new DataNotFoundException(Error.ErrorCodes.NOTFOUND_PERSONAL);
+            }
+
+            if (addressEntity is null)
+            {
+                throw new InvalidDataStateException(Error.FatalCodes.RESOURCE_WITHOUT_RELATED_ADDRESS);
+            }
+
+            personalEntity.is_deleted = true;
+            personalEntity.Update(_context);
+
+            addressEntity.is_deleted = true;
+            addressEntity.Update(_context);
+
+            new ChangeEntity()
+            {
+                change_type = ChangeEntity.ChangeType.DeleteResource,
+                element_id = personalEntity.id,
+                element_type = ChangeEntity.ElementType.Personal,
+                reason = reason,
+                timestamp = DateTime.Now
+            }.Insert(_context);
         }
 
         private string createToken()

--- a/init.sql
+++ b/init.sql
@@ -10,7 +10,8 @@ create table address
 	hascoordinates boolean default false not null,
 	latitude numeric,
 	longitude numeric,
-	street text
+	street text,
+	is_deleted boolean default false not null
 );
 
 alter table address owner to postgres;
@@ -59,7 +60,8 @@ create table consumable
 			references address
 				on update cascade on delete cascade,
 	unit text,
-	annotation text
+	annotation text,
+	is_deleted boolean default false not null
 );
 
 alter table consumable owner to postgres;
@@ -86,7 +88,8 @@ create table device
 		constraint device_address_id_fk
 			references address
 				on update cascade on delete cascade,
-	annotation text
+	annotation text,
+	is_deleted boolean default false not null
 );
 
 alter table device owner to postgres;
@@ -113,7 +116,8 @@ create table personal
 	address_id integer
 		constraint personal_address_id_fk
 			references address
-				on update cascade on delete cascade
+				on update cascade on delete cascade,
+	is_deleted boolean default false not null
 );
 
 alter table personal owner to postgres;


### PR DESCRIPTION
closes #75

Resources can be deleted. In fact not a total deletion since "deleted" entries are marked with is_deleted:true.

New column is_deleted in database for resources (including address).

Resources with is_deleted:true are not retrieved by queries called from the api.

Refactor class Change.