### PR TITLE
Remove hardcoded host and port

### DIFF
--- a/Pirat/Program.cs
+++ b/Pirat/Program.cs
@@ -49,7 +49,6 @@ namespace Pirat
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
-                    webBuilder.UseUrls("http://localhost:5000");
                 });
     }
 }


### PR DESCRIPTION
Removing the line in Program.cs will prevent overwriting the environment variable.

For the environment variable use: **ASPNETCORE_URLS** and as value http://Host:Port

Note that in launchsettings.json we still use "applicationUrl": "http://localhost:5000". This value will be taken instead of the env variable. However, it should be fine because it only applies in development mode and not in production according to the docs.