### PR TITLE
Swagger base path improvement

### DIFF
--- a/Pirat/Controllers/DemandController.cs
+++ b/Pirat/Controllers/DemandController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using Pirat.Codes;
 using Pirat.Configuration;
 using Pirat.Exceptions;
@@ -289,6 +290,8 @@ namespace Pirat.Controllers
             {
                 return BadRequest(e.Message);
             }
+
         }
     }
+
 }

--- a/Pirat/Controllers/ResourceController.cs
+++ b/Pirat/Controllers/ResourceController.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using Pirat.Codes;
 using Pirat.Extensions.Swagger.SwaggerConfiguration;
 using Pirat.Model.Api.Resource;
@@ -419,8 +421,6 @@ namespace Pirat.Controllers
         [HttpPut("offers/{token}/provider")]
         [Consumes("application/json")]
         [Produces("application/json")]
-        // There seems to be a bug in the used swagger library. The following line fixes the shown example.
-        [SwaggerRequestExample(typeof(string), typeof(ProviderRequestExample))]
         [SwaggerRequestExample(typeof(Provider), typeof(ProviderRequestExample))]
         [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(void))]
         [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(string))]
@@ -455,8 +455,6 @@ namespace Pirat.Controllers
         [HttpPut("offers/{token}/consumable/{id:int}")]
         [Consumes("application/json")]
         [Produces("application/json")]
-        // There seems to be a bug in the used swagger library. The following line fixes the shown example.
-        [SwaggerRequestExample(typeof(string), typeof(ConsumableRequestExample))]
         [SwaggerRequestExample(typeof(Consumable), typeof(ConsumableRequestExample))]
         [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(string))]
         [SwaggerResponseExample(StatusCodes.Status200OK, typeof(EmptyResponseExample))]
@@ -494,8 +492,6 @@ namespace Pirat.Controllers
         [HttpPut("offers/{token}/device/{id:int}")]
         [Consumes("application/json")]
         [Produces("application/json")]
-        // There seems to be a bug in the used swagger library. The following line fixes the shown example.
-        [SwaggerRequestExample(typeof(string), typeof(DeviceRequestExample))]
         [SwaggerRequestExample(typeof(Device), typeof(DeviceRequestExample))]
         [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(string))]
         [SwaggerResponseExample(StatusCodes.Status200OK, typeof(EmptyResponseExample))]
@@ -533,8 +529,6 @@ namespace Pirat.Controllers
         [HttpPut("offers/{token}/personal/{id:int}")]
         [Consumes("application/json")]
         [Produces("application/json")]
-        // There seems to be a bug in the used swagger library. The following line fixes the shown example.
-        [SwaggerRequestExample(typeof(string), typeof(PersonalRequestExample))]
         [SwaggerRequestExample(typeof(Personal), typeof(PersonalRequestExample))]
         [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(string))]
         [SwaggerResponseExample(StatusCodes.Status200OK, typeof(EmptyResponseExample))]
@@ -572,8 +566,6 @@ namespace Pirat.Controllers
         [HttpPut("offers/{token}/consumable/{id:int}/amount")]
         [Consumes("application/json")]
         [Produces("application/json")]
-        // There seems to be a bug in the used swagger library. The following line fixes the shown example.
-        [SwaggerRequestExample(typeof(string), typeof(AmountChangeRequestExample))]
         [SwaggerRequestExample(typeof(AmountChange), typeof(AmountChangeRequestExample))]
         [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(string))]
         [SwaggerResponseExample(StatusCodes.Status200OK, typeof(EmptyResponseExample))]
@@ -609,8 +601,6 @@ namespace Pirat.Controllers
         [HttpPut("offers/{token}/device/{id:int}/amount")]
         [Consumes("application/json")]
         [Produces("application/json")]
-        // There seems to be a bug in the used swagger library. The following line fixes the shown example.
-        [SwaggerRequestExample(typeof(string), typeof(AmountChangeRequestExample))]
         [SwaggerRequestExample(typeof(AmountChange), typeof(AmountChangeRequestExample))]
         [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(string))]
         [SwaggerResponseExample(StatusCodes.Status200OK, typeof(EmptyResponseExample))]
@@ -718,7 +708,6 @@ namespace Pirat.Controllers
         [HttpPost("offers/{token}/consumable")]
         [Consumes("application/json")]
         [Produces("application/json")]
-        [SwaggerRequestExample(typeof(string), typeof(ConsumableRequestExample))]
         [SwaggerRequestExample(typeof(Consumable), typeof(ConsumableRequestExample))]
         [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(string))]
         [SwaggerResponseExample(StatusCodes.Status200OK, typeof(EmptyResponseExample))]
@@ -753,7 +742,6 @@ namespace Pirat.Controllers
         [HttpPost("offers/{token}/device")]
         [Consumes("application/json")]
         [Produces("application/json")]
-        [SwaggerRequestExample(typeof(string), typeof(DeviceRequestExample))]
         [SwaggerRequestExample(typeof(Device), typeof(DeviceRequestExample))]
         [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(string))]
         [SwaggerResponseExample(StatusCodes.Status200OK, typeof(EmptyResponseExample))]
@@ -788,7 +776,6 @@ namespace Pirat.Controllers
         [HttpPost("offers/{token}/manpower")]
         [Consumes("application/json")]
         [Produces("application/json")]
-        [SwaggerRequestExample(typeof(string), typeof(PersonalRequestExample))]
         [SwaggerRequestExample(typeof(Personal), typeof(PersonalRequestExample))]
         [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(string))]
         [SwaggerResponseExample(StatusCodes.Status200OK, typeof(EmptyResponseExample))]
@@ -820,4 +807,34 @@ namespace Pirat.Controllers
             }
         }
     }
+
+    //[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
+    //public class MySwaggerResponseExampleAttribute : SwaggerResponseExampleAttribute
+    //{
+    //    public MySwaggerResponseExampleAttribute(
+    //        int statusCode,
+    //        Type examplesProviderType,
+    //        string description = null,
+    //        Type type = null,
+    //        Type contractResolver = null,
+    //        Type jsonConverter = null) : base(statusCode, examplesProviderType, contractResolver, jsonConverter)
+    //    {
+    //        this.StatusCode = statusCode;
+    //        Type type1 = type;
+    //        if ((object)type1 == null)
+    //            type1 = typeof(void);
+    //        // ISSUE: explicit constructor call
+    //        Type = type ?? throw new ArgumentNullException(nameof(type));
+    //        this.Description = description;
+    //    }
+
+    //    /// <summary>
+    //    /// A short description of the response. GFM syntax can be used for rich text representation.
+    //    /// </summary>
+    //    public string Description { get; set; }
+
+    //    public Type Type { get; }
+
+    //    public int StatusCode { get; }
+    //}
 }

--- a/Pirat/Controllers/ResourceController.cs
+++ b/Pirat/Controllers/ResourceController.cs
@@ -808,33 +808,4 @@ namespace Pirat.Controllers
         }
     }
 
-    //[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
-    //public class MySwaggerResponseExampleAttribute : SwaggerResponseExampleAttribute
-    //{
-    //    public MySwaggerResponseExampleAttribute(
-    //        int statusCode,
-    //        Type examplesProviderType,
-    //        string description = null,
-    //        Type type = null,
-    //        Type contractResolver = null,
-    //        Type jsonConverter = null) : base(statusCode, examplesProviderType, contractResolver, jsonConverter)
-    //    {
-    //        this.StatusCode = statusCode;
-    //        Type type1 = type;
-    //        if ((object)type1 == null)
-    //            type1 = typeof(void);
-    //        // ISSUE: explicit constructor call
-    //        Type = type ?? throw new ArgumentNullException(nameof(type));
-    //        this.Description = description;
-    //    }
-
-    //    /// <summary>
-    //    /// A short description of the response. GFM syntax can be used for rich text representation.
-    //    /// </summary>
-    //    public string Description { get; set; }
-
-    //    public Type Type { get; }
-
-    //    public int StatusCode { get; }
-    //}
 }

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/ConsumableRequestExample.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/ConsumableRequestExample.cs
@@ -9,17 +9,17 @@ namespace Pirat.Extensions.Swagger.SwaggerConfiguration
         {
             return new Consumable()
             {
-                unit = "Liter",
                 address = new Address()
                 {
-                    street = "Hauptstraße",
+                    street = "Leuchtturmstraße",
                     streetnumber = "77",
                     postalcode = "27498",
                     city = "Helgoland",
                     country = "Deutschland"
                 },
-                category = "Rum",
-                name = "Nordrum",
+                category = "MASKE",
+                name = "FFP2 Maske",
+                unit = "Packung",
                 manufacturer = "Störtebeker & Co",
                 ordernumber = "999",
                 amount = 100,

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/DemandRequestExample.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/DemandRequestExample.cs
@@ -22,8 +22,8 @@ namespace Pirat.Extensions.Swagger.SwaggerConfiguration
                         phone = "987654",
                         address = new Address()
                         {
-                            street = "Hauptstraße",
-                            streetnumber = "77",
+                            street = "Leuchtturmstraße",
+                            streetnumber = "716",
                             postalcode = "27498",
                             city = "Helgoland",
                             country = "Deutschland"

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/DeviceRequestExample.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/DeviceRequestExample.cs
@@ -11,14 +11,14 @@ namespace Pirat.Extensions.Swagger.SwaggerConfiguration
             {
                 address = new Address()
                 {
-                    street = "Hauptstraße",
-                    streetnumber = "77",
+                    street = "Leuchtturmstraße",
+                    streetnumber = "716",
                     postalcode = "27498",
                     city = "Helgoland",
                     country = "Deutschland"
                 },
-                category = "Schiffsmaterial",
-                name = "Steuerrad",
+                category = "ZENTRIFUGE",
+                name = "Ultrazentrifuge",
                 manufacturer = "Störtebeker & Co",
                 ordernumber = "12345",
                 amount = 10,

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/EmptyResponseExample.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/EmptyResponseExample.cs
@@ -2,9 +2,9 @@
 
 namespace Pirat.Extensions.Swagger.SwaggerConfiguration
 {
-    public class EmptyResponseExample : IExamplesProvider<string>
+    public class EmptyResponseExample : IExamplesProvider<object>
     {
-        public string GetExamples()
+        public object GetExamples()
         {
             return "";
         }

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/ErrorCodeResponseExample.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/ErrorCodeResponseExample.cs
@@ -2,9 +2,9 @@
 
 namespace Pirat.Extensions.Swagger.SwaggerConfiguration
 {
-    public class ErrorCodeResponseExample : IExamplesProvider<string>
+    public class ErrorCodeResponseExample : IExamplesProvider<object>
     {
-        public string GetExamples()
+        public object GetExamples()
         {
             return "XXXX:Description";
         }

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/OfferRequestExample.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/OfferRequestExample.cs
@@ -14,8 +14,8 @@ namespace Pirat.SwaggerConfiguration
                 {
                     address = new Address()
                     {
-                        street = "Hauptstraße",
-                        streetnumber = "77",
+                        street = "Leuchtturmstraße",
+                        streetnumber = "716",
                         postalcode = "27498",
                         city = "Helgoland",
                         country = "Deutschland",
@@ -30,18 +30,18 @@ namespace Pirat.SwaggerConfiguration
                 {
                     new Personal()
                     {
-                        qualification = "Kapitän",
-                        area = "Schiffsfahrt, Piraterie",
+                        qualification = "PHD_STUDENT",
+                        area = "MOLECULAR_BIOLOGY",
                         address = new Address()
                         {
-                            street = "Hauptstraße",
-                            streetnumber = "77",
+                            street = "Leuchtturmstraße",
+                            streetnumber = "716",
                             postalcode = "27498",
                             city = "Helgoland",
                             country = "Deutschland"
                         },
                         institution = "Institut für Piraterie",
-                        researchgroup = "Piraten Ahoi",
+                        researchgroup = "Biologie Piraten",
                         experience_rt_pcr = false,
                         annotation = "Ahoi!"
                     }
@@ -50,17 +50,17 @@ namespace Pirat.SwaggerConfiguration
                 {
                     new Consumable()
                     {
-                        unit = "Liter",
                         address = new Address()
                         {
-                            street = "Hauptstraße",
-                            streetnumber = "77",
+                            street = "Leuchtturmstraße",
+                            streetnumber = "716",
                             postalcode = "27498",
                             city = "Helgoland",
                             country = "Deutschland"
                         },
-                        category = "Rum",
-                        name = "Nordrum",
+                        category = "MASKE",
+                        name = "FFP2 Maske",
+                        unit = "Packung",
                         manufacturer = "Störtebeker & Co",
                         ordernumber = "999",
                         amount = 100,
@@ -73,14 +73,14 @@ namespace Pirat.SwaggerConfiguration
                     {
                         address = new Address()
                         {
-                            street = "Hauptstraße",
-                            streetnumber = "77",
+                            street = "Leuchtturmstraße",
+                            streetnumber = "716",
                             postalcode = "27498",
                             city = "Helgoland",
                             country = "Deutschland"
                         },
-                        category = "Schiffsmaterial",
-                        name = "Steuerrad",
+                        category = "ZENTRIFUGE",
+                        name = "Piratenzentrifuge",
                         manufacturer = "Störtebeker & Co",
                         ordernumber = "12345",
                         amount = 10,

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/OfferResourceResponseExample.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/OfferResourceResponseExample.cs
@@ -14,14 +14,14 @@ namespace Pirat.Extensions.Swagger.SwaggerConfiguration
                 {
                     address = new Address()
                     {
-                        street = "Hauptstraße",
-                        streetnumber = "77",
+                        street = "Leuchtturmstraße",
+                        streetnumber = "716",
                         postalcode = "27498",
                         city = "Helgoland",
                         country = "Deutschland",
                     },
                     name = "Störtebeker",
-                    organisation = "Instiut für Piraterie",
+                    organisation = "Institut für Piraterie",
                     phone = "987654",
                     mail = "pirat.hilfsmittel@gmail.com",
                     ispublic = true
@@ -30,17 +30,17 @@ namespace Pirat.Extensions.Swagger.SwaggerConfiguration
                 {
                     new Consumable()
                     {
-                        unit = "Liter",
                         address = new Address()
                         {
-                            street = "Hauptstraße",
-                            streetnumber = "77",
+                            street = "Leuchtturmstraße",
+                            streetnumber = "716",
                             postalcode = "27498",
                             city = "Helgoland",
                             country = "Deutschland"
                         },
-                        category = "Rum",
-                        name = "Nordrum",
+                        category = "MASKE",
+                        name = "FFP2 Maske",
+                        unit = "Packung",
                         manufacturer = "Störtebeker & Co",
                         ordernumber = "999",
                         amount = 100,
@@ -62,14 +62,14 @@ namespace Pirat.Extensions.Swagger.SwaggerConfiguration
                 {
                     address = new Address()
                     {
-                        street = "Hauptstraße",
+                        street = "Leuchtturmstraße",
                         streetnumber = "77",
                         postalcode = "27498",
                         city = "Helgoland",
                         country = "Deutschland",
                     },
                     name = "Störtebeker",
-                    organisation = "Instiut für Piraterie",
+                    organisation = "Institut für Piraterie",
                     phone = "987654",
                     mail = "pirat.hilfsmittel@gmail.com",
                     ispublic = true
@@ -80,14 +80,14 @@ namespace Pirat.Extensions.Swagger.SwaggerConfiguration
                     {
                         address = new Address()
                         {
-                            street = "Hauptstraße",
+                            street = "Leuchtturmstraße",
                             streetnumber = "77",
                             postalcode = "27498",
                             city = "Helgoland",
                             country = "Deutschland"
                         },
-                        category = "Schiffsmaterial",
-                        name = "Steuerrad",
+                        category = "ZENTRIFUGE",
+                        name = "Ultrazentrifuge",
                         manufacturer = "Störtebeker & Co",
                         ordernumber = "12345",
                         amount = 10,
@@ -109,14 +109,14 @@ namespace Pirat.Extensions.Swagger.SwaggerConfiguration
                 {
                     address = new Address()
                     {
-                        street = "Hauptstraße",
+                        street = "Leuchtturmstraße",
                         streetnumber = "77",
                         postalcode = "27498",
                         city = "Helgoland",
                         country = "Deutschland",
                     },
                     name = "Störtebeker",
-                    organisation = "Instiut für Piraterie",
+                    organisation = "Institut für Piraterie",
                     phone = "987654",
                     mail = "pirat.hilfsmittel@gmail.com",
                     ispublic = true
@@ -125,18 +125,18 @@ namespace Pirat.Extensions.Swagger.SwaggerConfiguration
                 {
                     new Personal()
                     {
-                        qualification = "Kapitän",
-                        area = "Schiffsfahrt, Piraterie",
+                        qualification = "PHD_STUDENT",
+                        area = "MOLECULAR_BIOLOGY",
                         address = new Address()
                         {
-                            street = "Hauptstraße",
+                            street = "Leuchtturmstraße",
                             streetnumber = "77",
                             postalcode = "27498",
                             city = "Helgoland",
                             country = "Deutschland"
                         },
                         institution = "Institut für Piraterie",
-                        researchgroup = "Piraten Ahoi",
+                        researchgroup = "Biologie Piraten",
                         experience_rt_pcr = false,
                         annotation = "Ahoi!",
                         id = 99999999

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/OfferResponseExample.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/OfferResponseExample.cs
@@ -14,8 +14,8 @@ namespace Pirat.Extensions.Swagger.SwaggerConfiguration
                 {
                     address = new Address()
                     {
-                        street = "Hauptstraße",
-                        streetnumber = "77",
+                        street = "Leuchtturmstraße",
+                        streetnumber = "716",
                         postalcode = "27498",
                         city = "Helgoland",
                         country = "Deutschland",
@@ -30,18 +30,18 @@ namespace Pirat.Extensions.Swagger.SwaggerConfiguration
                 {
                     new Personal()
                     {
-                        qualification = "Kapitän",
-                        area = "Schiffsfahrt, Piraterie",
+                        qualification = "PHD_STUDENT",
+                        area = "MOLECULAR_BIOLOGY",
                         address = new Address()
                         {
-                            street = "Hauptstraße",
-                            streetnumber = "77",
+                            street = "Leuchtturmstraße",
+                            streetnumber = "716",
                             postalcode = "27498",
                             city = "Helgoland",
                             country = "Deutschland"
                         },
                         institution = "Institut für Piraterie",
-                        researchgroup = "Piraten Ahoi",
+                        researchgroup = "Biologie Piraten",
                         experience_rt_pcr = false,
                         annotation = "Ahoi!",
                         id = 99999999
@@ -51,17 +51,17 @@ namespace Pirat.Extensions.Swagger.SwaggerConfiguration
                 {
                     new Consumable()
                     {
-                        unit = "Liter",
                         address = new Address()
                         {
-                            street = "Hauptstraße",
-                            streetnumber = "77",
+                            street = "Leuchtturmstraße",
+                            streetnumber = "716",
                             postalcode = "27498",
                             city = "Helgoland",
                             country = "Deutschland"
                         },
-                        category = "Rum",
-                        name = "Nordrum",
+                        category = "MASKE",
+                        name = "FFP2 Maske",
+                        unit = "Packung",
                         manufacturer = "Störtebeker & Co",
                         ordernumber = "999",
                         amount = 100,
@@ -75,14 +75,14 @@ namespace Pirat.Extensions.Swagger.SwaggerConfiguration
                     {
                         address = new Address()
                         {
-                            street = "Hauptstraße",
-                            streetnumber = "77",
+                            street = "Leuchtturmstraße",
+                            streetnumber = "716",
                             postalcode = "27498",
                             city = "Helgoland",
                             country = "Deutschland"
                         },
-                        category = "Schiffsmaterial",
-                        name = "Steuerrad",
+                        category = "Zentrifuge",
+                        name = "Ultrazentrifuge",
                         manufacturer = "Störtebeker & Co",
                         ordernumber = "12345",
                         amount = 10,

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/PersonalRequestExample.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/PersonalRequestExample.cs
@@ -9,18 +9,18 @@ namespace Pirat.Extensions.Swagger.SwaggerConfiguration
         {
             return new Personal()
             {
-                qualification = "Kapitän",
-                area = "Schiffsfahrt, Piraterie",
+                qualification = "PHD_STUDENT",
+                area = "MOLECULAR_BIOLOGY",
                 address = new Address()
                 {
-                    street = "Hauptstraße",
-                    streetnumber = "77",
+                    street = "Leuchtturmstraße",
+                    streetnumber = "716",
                     postalcode = "27498",
                     city = "Helgoland",
                     country = "Deutschland"
                 },
                 institution = "Institut für Piraterie",
-                researchgroup = "Piraten Ahoi",
+                researchgroup = "Biologie Piraten",
                 experience_rt_pcr = false,
                 annotation = "Ahoi!"
             };

--- a/Pirat/Extensions/Swagger/SwaggerConfiguration/ProviderRequestExample.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfiguration/ProviderRequestExample.cs
@@ -11,8 +11,8 @@ namespace Pirat.Extensions.Swagger.SwaggerConfiguration
             {
                 address = new Address()
                 {
-                    street = "Hauptstraße",
-                    streetnumber = "77",
+                    street = "Leuchtturmstraße",
+                    streetnumber = "716",
                     postalcode = "27498",
                     city = "Helgoland",
                     country = "Deutschland",

--- a/Pirat/Extensions/Swagger/SwaggerConfigurationExtensions.cs
+++ b/Pirat/Extensions/Swagger/SwaggerConfigurationExtensions.cs
@@ -25,6 +25,7 @@ namespace Pirat.Extensions.Swagger
             services.AddSwaggerExamplesFromAssemblyOf<PersonalRequestExample>();
             services.AddSwaggerExamplesFromAssemblyOf<AmountChangeRequestExample>();
             //Add more examples here for swagger response and swagger request
+            //If the example provider is type string use type object instead since type string will cause buggy behaviour in swagger output 
 
 
             services.AddSwaggerGen(c =>

--- a/Pirat/Program.cs
+++ b/Pirat/Program.cs
@@ -33,7 +33,8 @@ namespace Pirat
                 "PIRAT_GOOGLE_API_KEY",
                 "PIRAT_GOOGLE_RECAPTCHA_SECRET",
                 
-                "PIRAT_ADMIN_KEY"
+                "PIRAT_ADMIN_KEY",
+                "PIRAT_PREFIX_SWAGGER_ENDPOINT"
             };
             foreach (var requiredEnvironmentVariable in requiredEnvironmentVariables)
             {

--- a/Pirat/Program.cs
+++ b/Pirat/Program.cs
@@ -34,7 +34,7 @@ namespace Pirat
                 "PIRAT_GOOGLE_RECAPTCHA_SECRET",
                 
                 "PIRAT_ADMIN_KEY",
-                "PIRAT_PREFIX_SWAGGER_ENDPOINT"
+                "PIRAT_SWAGGER_PREFIX_PATH"
             };
             foreach (var requiredEnvironmentVariable in requiredEnvironmentVariables)
             {

--- a/Pirat/Properties/launchSettings.json
+++ b/Pirat/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "Pirat": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "api/swagger",
       "environmentVariables": {
 	      "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/Pirat/Startup.cs
+++ b/Pirat/Startup.cs
@@ -92,7 +92,7 @@ namespace Pirat
                 app.UseDeveloperExceptionPage();
 
                 //Swagger settings
-                var swaggerPrefix = Environment.GetEnvironmentVariable("PIRAT_PREFIX_SWAGGER_ENDPOINT");
+                var swaggerPrefix = Environment.GetEnvironmentVariable("PIRAT_SWAGGER_PREFIX_PATH");
                 var swaggerTemplate = Path.Combine(swaggerPrefix, "swagger/{documentname}/swagger.json");
                 var swaggerRoutePrefix = Path.Combine(swaggerPrefix, "swagger");
                 var swaggerEndpoint = "/" + Path.Combine(swaggerPrefix, "swagger/v1/swagger.json");

--- a/Pirat/Startup.cs
+++ b/Pirat/Startup.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
@@ -87,11 +88,15 @@ namespace Pirat
             {
                 logger.LogInformation("In Development environment");
                 Environment.SetEnvironmentVariable("PIRAT_HOST", "http://localhost:4200");
+                var swaggerPrefix = Environment.GetEnvironmentVariable("PIRAT_PREFIX_SWAGGER_ENDPOINT");
+                if(string.IsNullOrEmpty(swaggerPrefix)){
+                    swaggerPrefix = "";
+                }
                 app.UseDeveloperExceptionPage();
                 app.UseSwagger();
                 app.UseSwaggerUI(c =>
                 {
-                    c.SwaggerEndpoint("/swagger/v1/swagger.json", "Pirat API");
+                    c.SwaggerEndpoint(Path.Combine(swaggerPrefix, "/swagger/v1/swagger.json"), "Pirat API");
                 });
             }
             if (env.IsProduction())

--- a/Pirat/Startup.cs
+++ b/Pirat/Startup.cs
@@ -88,15 +88,25 @@ namespace Pirat
             {
                 logger.LogInformation("In Development environment");
                 Environment.SetEnvironmentVariable("PIRAT_HOST", "http://localhost:4200");
-                var swaggerPrefix = Environment.GetEnvironmentVariable("PIRAT_PREFIX_SWAGGER_ENDPOINT");
-                if(string.IsNullOrEmpty(swaggerPrefix)){
-                    swaggerPrefix = "";
-                }
+
                 app.UseDeveloperExceptionPage();
-                app.UseSwagger();
+
+                //Swagger settings
+                var swaggerPrefix = Environment.GetEnvironmentVariable("PIRAT_PREFIX_SWAGGER_ENDPOINT");
+                var swaggerTemplate = Path.Combine(swaggerPrefix, "swagger/{documentname}/swagger.json");
+                var swaggerRoutePrefix = Path.Combine(swaggerPrefix, "swagger");
+                var swaggerEndpoint = "/" + Path.Combine(swaggerPrefix, "swagger/v1/swagger.json");
+                logger.LogDebug($"Swagger template: {swaggerTemplate}");
+                logger.LogDebug($"Swagger route prefix: {swaggerRoutePrefix}");
+                logger.LogDebug($"Swagger endpoint: {swaggerEndpoint}");
+                app.UseSwagger(c =>
+                {
+                    c.RouteTemplate = swaggerTemplate;
+                });
                 app.UseSwaggerUI(c =>
                 {
-                    c.SwaggerEndpoint(Path.Combine(swaggerPrefix, "/swagger/v1/swagger.json"), "Pirat API");
+                    c.RoutePrefix = swaggerRoutePrefix;
+                    c.SwaggerEndpoint(swaggerEndpoint, "Pirat API");
                 });
             }
             if (env.IsProduction())


### PR DESCRIPTION
Swagger path prefix can now be configured via environment variable so that swagger can now be started under a new endpoint.

For instance: HOST:PORT/api/swagger/...      <- here is "api/" the prefix based on the env variable value

Env variable is **PIRAT_SWAGGER_PREFIX_PATH**
Setting the env variable is mandatory

In the launchsettings.json "api/swagger" is now the starting url, so "api/" has to be set as env variable for developping.

Do not set a value for the env variable that starts with "/". Swagger will fail. (We could remove a beginning slash but I don't like the idea of fixing environment variable values during runtime.

The value of the env variable can stop with an "/" but can be ommitted as well. Path.Combine in C# makes the job for this.

Fixed also the resource request examples. Störtebeker now has an existing address and sends/requests utilities which make sense. Examples should work.

Fixed also the bug with the unexpected behavior for SwaggerRequestExample. Do not use strings in the type for IProvider in the swagger examples.