### PR TITLE
Remove postalcode field of resources 127

### DIFF
--- a/Pirat.DatabaseTests/ResourceChangeTest.cs
+++ b/Pirat.DatabaseTests/ResourceChangeTest.cs
@@ -215,7 +215,7 @@ namespace Pirat.DatabaseTests
             Assert.True(changedRows == 0);
 
             //Generate the consumable for the query that should still be findable 
-            Consumable queryConsumable = _captainHookGenerator.GenerateConsumable();
+            Consumable queryConsumable = _captainHookGenerator.GenerateQueryConsumable();
             var response = await _resourceStockQueryService.QueryOffersAsync(queryConsumable, "de")
                 .ToListAsync();
 
@@ -284,7 +284,7 @@ namespace Pirat.DatabaseTests
             Assert.True(changedRows == 0);
 
             //The original device should still be findable
-            Device queryDevice = _captainHookGenerator.GenerateDevice();
+            Device queryDevice = _captainHookGenerator.GenerateQueryDevice();
             var response = await _resourceStockQueryService.QueryOffersAsync(queryDevice, "de")
                 .ToListAsync();
 
@@ -355,7 +355,7 @@ namespace Pirat.DatabaseTests
             Assert.True(changedRows == 0);
 
             //The personal in the original manpower should still be findable
-            Manpower queryManpower = _captainHookGenerator.GenerateManpower();
+            Manpower queryManpower = _captainHookGenerator.GenerateQueryManpower();
             var response = await _resourceStockQueryService.QueryOffersAsync(queryManpower, "de")
                 .ToListAsync();
 

--- a/Pirat.DatabaseTests/ResourceChangeTest.cs
+++ b/Pirat.DatabaseTests/ResourceChangeTest.cs
@@ -173,7 +173,7 @@ namespace Pirat.DatabaseTests
 
             //Update
             var changedRows = await _resourceStockUpdateService.ChangeInformationAsync(_token, consumable);
-            Assert.True(changedRows == 2);
+            Assert.True(changedRows == 1);
 
             //Generate a consumable with the necessary attributes to find the updated consumable
             Consumable queryConsumable = new Consumable()
@@ -242,7 +242,7 @@ namespace Pirat.DatabaseTests
 
             //Update
             var changedRows = await _resourceStockUpdateService.ChangeInformationAsync(_token, device);
-            Assert.True(changedRows == 2);
+            Assert.True(changedRows == 1);
 
             //Generate a device with the necessary attributes to find the updated device
             Device queryDevice = new Device()
@@ -314,7 +314,7 @@ namespace Pirat.DatabaseTests
 
             //Update
             var changedRows = await _resourceStockUpdateService.ChangeInformationAsync(_token, personal);
-            Assert.True(changedRows == 2);
+            Assert.True(changedRows == 1);
 
             //Create manpower to find the updated personal
             Manpower queryManpower = new Manpower()

--- a/Pirat.DatabaseTests/ResourceChangeTest.cs
+++ b/Pirat.DatabaseTests/ResourceChangeTest.cs
@@ -181,8 +181,8 @@ namespace Pirat.DatabaseTests
                 category = consumable.category,
                 address = new Address()
                 {
-                    postalcode = consumable.address.postalcode,
-                    country = consumable.address.country
+                    postalcode = _offer.provider.address.postalcode,
+                    country = _offer.provider.address.country
                 }
             };
             var response = await _resourceStockQueryService.QueryOffersAsync(queryConsumable, "de")
@@ -209,10 +209,6 @@ namespace Pirat.DatabaseTests
             var idOriginal = consumable.id;
             consumable.category = "Doch was anderes";
             consumable.id = 999999;
-
-            //Gets ignored because entity has no address
-            consumable.address.postalcode = "85521";
-            consumable.address.country = "Deutschland";
 
             //Try to update
             var changedRows = await _resourceStockUpdateService.ChangeInformationAsync(_token, consumable);
@@ -253,8 +249,8 @@ namespace Pirat.DatabaseTests
             {
                 address = new Address()
                 {
-                    postalcode = device.address.postalcode,
-                    country = device.address.country
+                    postalcode = _offer.provider.address.postalcode,
+                    country = _offer.provider.address.country
                 },
                 category = device.category
             };
@@ -282,10 +278,6 @@ namespace Pirat.DatabaseTests
             var idOriginal = device.id;
             device.category = "Doch was anderes";
             device.id = 999999;
-
-            //Will have no effect because device entity has no address
-            device.address.postalcode = "85521";
-            device.address.country = "Deutschland";
 
             //Try to update
             var changedRows = await _resourceStockUpdateService.ChangeInformationAsync(_token, device);
@@ -331,8 +323,8 @@ namespace Pirat.DatabaseTests
                 area = new List<string>() { "Piratenforschung"},
                 address = new Address()
                 {
-                    postalcode = personal.address.postalcode,
-                    country = personal.address.country,
+                    postalcode = _offer.provider.address.postalcode,
+                    country = _offer.provider.address.country,
                 }
             };
             var response = await _resourceStockQueryService.QueryOffersAsync(queryManpower, "de")
@@ -357,10 +349,6 @@ namespace Pirat.DatabaseTests
             Personal personal = _offer.personals[0];
             var idOriginal = personal.id;
             personal.id = 999999;
-
-            //Getting ignored because entity has no address
-            personal.address.postalcode = "85521";
-            personal.address.country = "Deutschland";
 
             //Try to update
             var changedRows = await _resourceStockUpdateService.ChangeInformationAsync(_token, personal);
@@ -393,39 +381,9 @@ namespace Pirat.DatabaseTests
             Assert.True(changedRows == 1);
         }
 
-        //Device, consumable and personal address changes gets ignored because they do not have an address 
+        //Tests for provider, device, consumable and personal in chaning information
         [Fact]
-        public async Task Test_ChangeInformation_OnlyAddress_Possible()
-        {
-            //Change
-            Consumable consumable = _offer.consumables[0];
-            consumable.address.postalcode = "85521";
-            consumable.address.country = "Deutschland";
-            //Update
-            var changedRows = await _resourceStockUpdateService.ChangeInformationAsync(_token, consumable);
-            Assert.True(changedRows == 0);
-            
-            //Change
-            Device device = _offer.devices[0];
-            device.address.postalcode = "85521";
-            device.address.country = "Deutschland";
-            //Update
-            changedRows = await _resourceStockUpdateService.ChangeInformationAsync(_token, device);
-            Assert.True(changedRows == 0);
-            
-            //Change
-            Personal personal = _offer.personals[0];
-            personal.address.postalcode = "85521";
-            personal.address.country = "Deutschland";
-            //Update
-            changedRows = await _resourceStockUpdateService.ChangeInformationAsync(_token, personal);
-            Assert.True(changedRows == 0);
-            
-        }
-
-        //Tests for provider, device, consumable and personal that include only changes in non-address information 
-        [Fact]
-        public async Task Test_ChangeInformation_AddressUnchanged_Possible()
+        public async Task Test_ChangeInformation_Possible()
         {
             //Change
             Provider provider = _offer.provider;

--- a/Pirat.DatabaseTests/ResourceChangeTest.cs
+++ b/Pirat.DatabaseTests/ResourceChangeTest.cs
@@ -127,7 +127,7 @@ namespace Pirat.DatabaseTests
             Provider providerFromOffer = response.provider;
             Console.Out.WriteLine(providerFromOffer);
             Console.Out.WriteLine(provider);
-            Assert.True(providerFromOffer.Equals(provider));
+            Assert.Equal(provider, providerFromOffer);
         }
 
         /// <summary>
@@ -194,7 +194,7 @@ namespace Pirat.DatabaseTests
             Consumable consumableFromQuery = response.First().resource;
             Console.Out.WriteLine(consumableFromQuery);
             Console.Out.WriteLine(consumable);
-            Assert.True(consumableFromQuery.Equals(consumable));
+            Assert.Equal(consumable, consumableFromQuery);
         }
 
         /// <summary>
@@ -263,7 +263,7 @@ namespace Pirat.DatabaseTests
             Device deviceFromQuery = response.First().resource;
             Console.Out.WriteLine(deviceFromQuery);
             Console.Out.WriteLine(device);
-            Assert.True(deviceFromQuery.Equals(device));
+            Assert.Equal(device, deviceFromQuery);
         }
 
         /// <summary>
@@ -292,7 +292,7 @@ namespace Pirat.DatabaseTests
             Assert.NotNull(response);
             Assert.NotEmpty(response);
             var deviceFromQuery = response.First().resource;
-            Assert.True(deviceFromQuery.category.Equals(categoryOriginal));
+            Assert.Equal(categoryOriginal, deviceFromQuery.category);
             Assert.True(deviceFromQuery.id == idOriginal);
         }
 
@@ -336,7 +336,7 @@ namespace Pirat.DatabaseTests
             Personal personalFromQuery = response.First().resource;
             Console.Out.WriteLine(personalFromQuery);
             Console.Out.WriteLine(personal);
-            Assert.True(personalFromQuery.Equals(personal));
+            Assert.Equal(personal, personalFromQuery);
         }
 
         /// <summary>

--- a/Pirat.DatabaseTests/ResourceChangeTest.cs
+++ b/Pirat.DatabaseTests/ResourceChangeTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -169,8 +170,6 @@ namespace Pirat.DatabaseTests
             consumable.annotation = "Geändert";
             consumable.manufacturer = "Doch wer anders";
             consumable.ordernumber = "8877766";
-            consumable.address.postalcode = "85521";
-            consumable.address.country = "Deutschland";
 
             //Update
             var changedRows = await _resourceStockUpdateService.ChangeInformationAsync(_token, consumable);
@@ -182,8 +181,8 @@ namespace Pirat.DatabaseTests
                 category = consumable.category,
                 address = new Address()
                 {
-                    postalcode = "85521",
-                    country = "Deutschland"
+                    postalcode = consumable.address.postalcode,
+                    country = consumable.address.country
                 }
             };
             var response = await _resourceStockQueryService.QueryOffersAsync(queryConsumable, "de")
@@ -210,6 +209,10 @@ namespace Pirat.DatabaseTests
             var idOriginal = consumable.id;
             consumable.category = "Doch was anderes";
             consumable.id = 999999;
+
+            //Gets ignored because entity has no address
+            consumable.address.postalcode = "85521";
+            consumable.address.country = "Deutschland";
 
             //Try to update
             var changedRows = await _resourceStockUpdateService.ChangeInformationAsync(_token, consumable);
@@ -240,8 +243,6 @@ namespace Pirat.DatabaseTests
             device.annotation = "Geändert";
             device.manufacturer = "Doch wer anders";
             device.ordernumber = "8877766";
-            device.address.postalcode = "85521";
-            device.address.country = "Deutschland";
 
             //Update
             var changedRows = await _resourceStockUpdateService.ChangeInformationAsync(_token, device);
@@ -252,8 +253,8 @@ namespace Pirat.DatabaseTests
             {
                 address = new Address()
                 {
-                    postalcode = "85521",
-                    country = "Deutschland"
+                    postalcode = device.address.postalcode,
+                    country = device.address.country
                 },
                 category = device.category
             };
@@ -281,6 +282,10 @@ namespace Pirat.DatabaseTests
             var idOriginal = device.id;
             device.category = "Doch was anderes";
             device.id = 999999;
+
+            //Will have no effect because device entity has no address
+            device.address.postalcode = "85521";
+            device.address.country = "Deutschland";
 
             //Try to update
             var changedRows = await _resourceStockUpdateService.ChangeInformationAsync(_token, device);
@@ -312,8 +317,6 @@ namespace Pirat.DatabaseTests
             personal.area = "Piratenforschung";
             personal.annotation = "Hier ein neuer Text";
             personal.experience_rt_pcr = false;
-            personal.address.postalcode = "85521";
-            personal.address.country = "Deutschland";
             personal.researchgroup = "Akademische Piraten";
             personal.institution = "TU Pirates";
 
@@ -328,8 +331,8 @@ namespace Pirat.DatabaseTests
                 area = new List<string>() { "Piratenforschung"},
                 address = new Address()
                 {
-                    postalcode = "85521",
-                    country = "Deutschland",
+                    postalcode = personal.address.postalcode,
+                    country = personal.address.country,
                 }
             };
             var response = await _resourceStockQueryService.QueryOffersAsync(queryManpower, "de")
@@ -355,6 +358,10 @@ namespace Pirat.DatabaseTests
             var idOriginal = personal.id;
             personal.id = 999999;
 
+            //Getting ignored because entity has no address
+            personal.address.postalcode = "85521";
+            personal.address.country = "Deutschland";
+
             //Try to update
             var changedRows = await _resourceStockUpdateService.ChangeInformationAsync(_token, personal);
             Assert.True(changedRows == 0);
@@ -371,9 +378,11 @@ namespace Pirat.DatabaseTests
             Assert.True(personalFromQuery.id == idOriginal);
         }
 
-        //Tests for provider, device, consumable and personal that include changes only in address information 
+        /// <summary>
+        /// Test to check the possibility of changing provider address
+        /// </summary>
         [Fact]
-        public async Task Test_ChangeInformation_OnlyAddress_Possible()
+        public async Task Test_ChangeAddress_Provider_Possible()
         {
             //Change
             Provider provider = _offer.provider;
@@ -382,14 +391,19 @@ namespace Pirat.DatabaseTests
             //Update
             var changedRows = await _resourceStockUpdateService.ChangeInformationAsync(_token, provider);
             Assert.True(changedRows == 1);
-            
+        }
+
+        //Device, consumable and personal address changes gets ignored because they do not have an address 
+        [Fact]
+        public async Task Test_ChangeInformation_OnlyAddress_Possible()
+        {
             //Change
             Consumable consumable = _offer.consumables[0];
             consumable.address.postalcode = "85521";
             consumable.address.country = "Deutschland";
             //Update
-            changedRows = await _resourceStockUpdateService.ChangeInformationAsync(_token, consumable);
-            Assert.True(changedRows == 1);
+            var changedRows = await _resourceStockUpdateService.ChangeInformationAsync(_token, consumable);
+            Assert.True(changedRows == 0);
             
             //Change
             Device device = _offer.devices[0];
@@ -397,7 +411,7 @@ namespace Pirat.DatabaseTests
             device.address.country = "Deutschland";
             //Update
             changedRows = await _resourceStockUpdateService.ChangeInformationAsync(_token, device);
-            Assert.True(changedRows == 1);
+            Assert.True(changedRows == 0);
             
             //Change
             Personal personal = _offer.personals[0];
@@ -405,7 +419,7 @@ namespace Pirat.DatabaseTests
             personal.address.country = "Deutschland";
             //Update
             changedRows = await _resourceStockUpdateService.ChangeInformationAsync(_token, personal);
-            Assert.True(changedRows == 1);
+            Assert.True(changedRows == 0);
             
         }
 
@@ -575,7 +589,6 @@ namespace Pirat.DatabaseTests
             newConsumable.amount = 20;
             newConsumable.category = "PIPETTENSPITZEN";
             Personal newPersonal = _captainHookGenerator.GeneratePersonal();
-            newPersonal.address.postalcode = "22459";
             newPersonal.qualification = "PHD_STUDENT";
 
             await _resourceStockUpdateService.AddResourceAsync(_token, newDevice);

--- a/Pirat.DatabaseTests/ResourceDeleteTest.cs
+++ b/Pirat.DatabaseTests/ResourceDeleteTest.cs
@@ -233,7 +233,7 @@ namespace Pirat.DatabaseTests
             Assert.Empty(foundOffer.devices);
 
             //Device should not be retrieved by querying with a device object
-            var deviceForQuery = _captainHookGenerator.GenerateDevice();
+            var deviceForQuery = _captainHookGenerator.GenerateQueryDevice();
             var foundDevices = await _resourceStockQueryService.QueryOffersAsync(deviceForQuery, "de").ToListAsync();
             Assert.NotNull(foundDevices);
             Assert.Empty(foundDevices);

--- a/Pirat.DatabaseTests/ResourceStockInsertTest.cs
+++ b/Pirat.DatabaseTests/ResourceStockInsertTest.cs
@@ -84,7 +84,7 @@ namespace Pirat.DatabaseTests
             //Now query the elements. If it is not empty we received the element back
 
             //Get device
-            var queryDevice = _captainHookGenerator.GenerateDevice();
+            var queryDevice = _captainHookGenerator.GenerateQueryDevice();
             var resultDevices = await _resourceStockQueryService.QueryOffersAsync(queryDevice, "de")
                 .ToListAsync();
             Assert.NotNull(resultDevices);
@@ -105,7 +105,7 @@ namespace Pirat.DatabaseTests
             // Assert.True(providerOriginal.Equals(providerFromQuery));
 
             //Get consumable
-            var queryConsumable = _captainHookGenerator.GenerateConsumable();
+            var queryConsumable = _captainHookGenerator.GenerateQueryConsumable();
             var resultConsumables = await _resourceStockQueryService.QueryOffersAsync(queryConsumable, "de")
                 .ToListAsync();
             Assert.NotNull(resultConsumables);
@@ -117,7 +117,7 @@ namespace Pirat.DatabaseTests
             Assert.True(consumableOriginal.Equals(consumableFromQuery));
 
             //Get personal
-            var manpowerQuery = _captainHookGenerator.GenerateManpower();
+            var manpowerQuery = _captainHookGenerator.GenerateQueryManpower();
             var resultPersonal = await _resourceStockQueryService.QueryOffersAsync(manpowerQuery, "de")
                 .ToListAsync();
             Assert.NotNull(resultPersonal);
@@ -142,7 +142,7 @@ namespace Pirat.DatabaseTests
             Assert.True(token.Length == 30);
 
             //Get device
-            var queryDevice = _shyPirateGenerator.GenerateDevice();
+            var queryDevice = _shyPirateGenerator.GenerateQueryDevice();
             var resultDevices = await _resourceStockQueryService.QueryOffersAsync(queryDevice, "de")
                 .ToListAsync();
             Assert.NotNull(resultDevices);

--- a/Pirat.DatabaseTests/ResourceStockInsertTest.cs
+++ b/Pirat.DatabaseTests/ResourceStockInsertTest.cs
@@ -139,6 +139,7 @@ namespace Pirat.DatabaseTests
         {
             var offer = _shyPirateGenerator.generateOffer();
             var token = await _resourceStockUpdateService.InsertAsync(offer, "de");
+            Assert.True(token.Length == 30);
 
             //Get device
             var queryDevice = _shyPirateGenerator.GenerateDevice();

--- a/Pirat.DatabaseTests/ResourceStockInsertTest.cs
+++ b/Pirat.DatabaseTests/ResourceStockInsertTest.cs
@@ -93,7 +93,7 @@ namespace Pirat.DatabaseTests
             var deviceOriginal = offer.devices.First();
             Console.Out.WriteLine(deviceFromQuery);
             Console.Out.WriteLine(deviceOriginal);
-            Assert.True(deviceOriginal.Equals(deviceFromQuery));
+            Assert.Equal(deviceOriginal, deviceFromQuery);
 
             //check the provider
             var providerFromQuery = resultDevices.First().provider; 
@@ -114,7 +114,7 @@ namespace Pirat.DatabaseTests
             var consumableOriginal = offer.consumables.First();
             Console.Out.WriteLine(consumableFromQuery);
             Console.Out.WriteLine(consumableOriginal);
-            Assert.True(consumableOriginal.Equals(consumableFromQuery));
+            Assert.Equal(consumableOriginal, consumableFromQuery);
 
             //Get personal
             var manpowerQuery = _captainHookGenerator.GenerateQueryManpower();
@@ -151,7 +151,7 @@ namespace Pirat.DatabaseTests
             var deviceOriginal = offer.devices.First();
             Console.Out.WriteLine(deviceFromQuery);
             Console.Out.WriteLine(deviceOriginal);
-            Assert.True(deviceOriginal.Equals(deviceFromQuery));
+            Assert.Equal(deviceOriginal, deviceFromQuery);
 
             //check the provider
             var providerFromQuery = resultDevices.First().provider;

--- a/Pirat.Examples/TestExamples/AnneBonnyGenerator.cs
+++ b/Pirat.Examples/TestExamples/AnneBonnyGenerator.cs
@@ -5,7 +5,7 @@ namespace Pirat.DatabaseTests.Examples
 {
     public class AnneBonnyGenerator
     {
-        public Address generateAddress()
+        public Address generateProviderAddress()
         {
             return new Address()
             {
@@ -21,7 +21,7 @@ namespace Pirat.DatabaseTests.Examples
                 category = "ZENTRIFUGE",
                 name = "BermudaTriangle",
                 manufacturer = "Maestral",
-                address = generateAddress(),
+                address = null,
                 amount = 1
             };
         }
@@ -35,7 +35,7 @@ namespace Pirat.DatabaseTests.Examples
                 experience_rt_pcr = true,
                 qualification = "Heart Surgeon",
                 area = "Piraten",
-                address = generateAddress()
+                address = null
             };
         }
 
@@ -48,7 +48,7 @@ namespace Pirat.DatabaseTests.Examples
                 manufacturer = "Sober Inc",
                 amount = 20,
                 unit = "Stück",
-                address = generateAddress()
+                address = null
             };
         }
 
@@ -61,7 +61,7 @@ namespace Pirat.DatabaseTests.Examples
                 phone = "1720",
                 mail = "annebonny.revenge@gmx.de",
                 ispublic = true,
-                address = generateAddress()
+                address = generateProviderAddress()
             };
         }
 

--- a/Pirat.Examples/TestExamples/CaptainHookGenerator.cs
+++ b/Pirat.Examples/TestExamples/CaptainHookGenerator.cs
@@ -9,7 +9,7 @@ namespace Pirat.Examples.TestExamples
     public class CaptainHookGenerator
     {
 
-        public Address generateAddress()
+        public Address generateProviderAddress()
         {
             return new Address()
             {
@@ -25,7 +25,7 @@ namespace Pirat.Examples.TestExamples
                 category = "PCR_THERMOCYCLER",
                 name = "Zeitticker",
                 manufacturer = "Piratenrolex",
-                address = generateAddress(),
+                address = null,
                 amount = 5
             };
         }
@@ -39,7 +39,7 @@ namespace Pirat.Examples.TestExamples
                 experience_rt_pcr = false,
                 qualification = "Entern",
                 area = "Piraten",
-                address = generateAddress()
+                address = null
             };
         }
 
@@ -52,7 +52,7 @@ namespace Pirat.Examples.TestExamples
                 experience_rt_pcr = false,
                 qualification = new List<string>(){"Entern"},
                 area = new List<string>(){"Piraten"},
-                address = generateAddress()
+                address = generateProviderAddress()
             };
         }
 
@@ -65,7 +65,7 @@ namespace Pirat.Examples.TestExamples
                 manufacturer = "HookInc",
                 amount = 40,
                 unit = "Packung",
-                address = generateAddress()
+                address = null
             };
         }
 
@@ -78,7 +78,7 @@ namespace Pirat.Examples.TestExamples
                 phone = "546389",
                 mail = "captainhook.neverland@gmx.de",
                 ispublic = true,
-                address = generateAddress()
+                address = generateProviderAddress()
             };
         }
 

--- a/Pirat.Examples/TestExamples/CaptainHookGenerator.cs
+++ b/Pirat.Examples/TestExamples/CaptainHookGenerator.cs
@@ -30,6 +30,18 @@ namespace Pirat.Examples.TestExamples
             };
         }
 
+        public Device GenerateQueryDevice()
+        {
+            return new Device()
+            {
+                category = "PCR_THERMOCYCLER",
+                name = "Zeitticker",
+                manufacturer = "Piratenrolex",
+                address = generateProviderAddress(),
+                amount = 5,
+            };
+        }
+
         public Personal GeneratePersonal()
         {
             return new Personal()
@@ -66,6 +78,19 @@ namespace Pirat.Examples.TestExamples
                 amount = 40,
                 unit = "Packung",
                 address = null
+            };
+        }
+
+        public Consumable GenerateQueryConsumable()
+        {
+            return new Consumable()
+            {
+                category = "SCHUTZKLEIDUNG",
+                name = "Hook3000",
+                manufacturer = "HookInc",
+                amount = 40,
+                unit = "Packung",
+                address = generateProviderAddress()
             };
         }
 

--- a/Pirat.Examples/TestExamples/CaptainHookGenerator.cs
+++ b/Pirat.Examples/TestExamples/CaptainHookGenerator.cs
@@ -55,7 +55,7 @@ namespace Pirat.Examples.TestExamples
             };
         }
 
-        public Manpower GenerateManpower()
+        public Manpower GenerateQueryManpower()
         {
             return new Manpower()
             {

--- a/Pirat.Examples/TestExamples/ShyPirateGenerator.cs
+++ b/Pirat.Examples/TestExamples/ShyPirateGenerator.cs
@@ -5,7 +5,7 @@ namespace Pirat.Examples.TestExamples
 {
     public class ShyPirateGenerator
     {
-        public Address generateAddress()
+        public Address generateProviderAddress()
         {
             return new Address()
             {
@@ -21,7 +21,7 @@ namespace Pirat.Examples.TestExamples
                 category = "PCR_THERMOCYCLER",
                 name = "Piratenstecher",
                 manufacturer = "W.Turner",
-                address = generateAddress(),
+                address = null,
                 amount = 5
             };
         }
@@ -34,7 +34,7 @@ namespace Pirat.Examples.TestExamples
                 organisation = "Shy Pirates",
                 mail = "pirate.shy@gmail.de",
                 ispublic = false,
-                address = generateAddress()
+                address = generateProviderAddress()
             };
         }
 

--- a/Pirat.Examples/TestExamples/ShyPirateGenerator.cs
+++ b/Pirat.Examples/TestExamples/ShyPirateGenerator.cs
@@ -26,6 +26,18 @@ namespace Pirat.Examples.TestExamples
             };
         }
 
+        public Device GenerateQueryDevice()
+        {
+            return new Device()
+            {
+                category = "PCR_THERMOCYCLER",
+                name = "Piratenstecher",
+                manufacturer = "W.Turner",
+                address = generateProviderAddress(),
+                amount = 5
+            };
+        }
+
         public Provider GenerateProvider()
         {
             return new Provider()

--- a/Pirat.Tests/ResourceDemandInputValidatorTest.cs
+++ b/Pirat.Tests/ResourceDemandInputValidatorTest.cs
@@ -26,17 +26,17 @@ namespace Pirat.Tests
         public void QueryConsumable_BadInputs()
         {
             //Invalid category
-            var consumable = _captainHookGenerator.GenerateConsumable();
+            var consumable = _captainHookGenerator.GenerateQueryConsumable();
             consumable.category = "";
             Assert.Throws<ArgumentException>(() => _service.ValidateForDemandQuery(consumable));
 
             //Country empty but postal code specified
-            consumable = _captainHookGenerator.GenerateConsumable();
+            consumable = _captainHookGenerator.GenerateQueryConsumable();
             consumable.address.country = "";
             Assert.Throws<ArgumentException>(() => _service.ValidateForDemandQuery(consumable));
 
             //Negative kilometer
-            consumable = _captainHookGenerator.GenerateConsumable();
+            consumable = _captainHookGenerator.GenerateQueryConsumable();
             consumable.kilometer = -10;
             Assert.Throws<ArgumentException>(() => _service.ValidateForDemandQuery(consumable));
         }
@@ -48,7 +48,7 @@ namespace Pirat.Tests
         public void QueryConsumable_AllowedInputs()
         {
             //Country and postalcode can be empty both
-            var consumable = _captainHookGenerator.GenerateConsumable();
+            var consumable = _captainHookGenerator.GenerateQueryConsumable();
             consumable.address.country = "";
             consumable.address.postalcode = "";
             var exception = Record.Exception(() => _service.ValidateForDemandQuery(consumable));
@@ -62,17 +62,17 @@ namespace Pirat.Tests
         public void QueryDevice_BadInputs()
         {
             //Invalid category
-            var device = _captainHookGenerator.GenerateDevice();
+            var device = _captainHookGenerator.GenerateQueryDevice();
             device.category = "";
             Assert.Throws<ArgumentException>(() => _service.ValidateForDemandQuery(device));
 
             //Country empty but postal code specified
-            device = _captainHookGenerator.GenerateDevice();
+            device = _captainHookGenerator.GenerateQueryDevice();
             device.address.country = "";
             Assert.Throws<ArgumentException>(() => _service.ValidateForDemandQuery(device));
 
             //Negative kilometer
-            device = _captainHookGenerator.GenerateDevice();
+            device = _captainHookGenerator.GenerateQueryDevice();
             device.kilometer = -10;
             Assert.Throws<ArgumentException>(() => _service.ValidateForDemandQuery(device));
         }
@@ -84,7 +84,7 @@ namespace Pirat.Tests
         public void QueryDevice_AllowedInputs()
         {
             //Country and postalcode can be empty both
-            var device = _captainHookGenerator.GenerateDevice();
+            var device = _captainHookGenerator.GenerateQueryDevice();
             device.address.country = "";
             device.address.postalcode = "";
             var exception = Record.Exception(() => _service.ValidateForDemandQuery(device));

--- a/Pirat.Tests/ResourceStockInputValidatorTest.cs
+++ b/Pirat.Tests/ResourceStockInputValidatorTest.cs
@@ -60,7 +60,6 @@ namespace Pirat.Tests
             newConsumable.amount = 0; // Invalid!
             newConsumable.category = "PIPETTENSPITZEN";
             Personal newPersonal = _captainHookGenerator.GeneratePersonal();
-            newPersonal.address.postalcode = "22459";
             newPersonal.qualification = null; // Invalid!
 
             Assert.Throws<ArgumentException>(() => _service.ValidateForStockInsertion(newDevice));
@@ -74,11 +73,11 @@ namespace Pirat.Tests
         [Fact]
         public void QueryConsumable_BadInputs()
         {
-            var consumable = _captainHookGenerator.GenerateConsumable();
+            var consumable = _captainHookGenerator.GenerateQueryConsumable();
             consumable.category = "";
             Assert.Throws<ArgumentException>(() => _service.ValidateForStockQuery(consumable));
 
-            consumable = _captainHookGenerator.GenerateConsumable();
+            consumable = _captainHookGenerator.GenerateQueryConsumable();
             consumable.address.country = "";
             Assert.Throws<ArgumentException>(() => _service.ValidateForStockQuery(consumable));
         }
@@ -86,11 +85,11 @@ namespace Pirat.Tests
         [Fact]
         public void QueryDevice_BadInputs()
         {
-            var device = _captainHookGenerator.GenerateDevice();
+            var device = _captainHookGenerator.GenerateQueryDevice();
             device.category = "";
             Assert.Throws<ArgumentException>(() => _service.ValidateForStockQuery(device));
 
-            device = _captainHookGenerator.GenerateDevice();
+            device = _captainHookGenerator.GenerateQueryDevice();
             device.address.postalcode = "";
             Assert.Throws<ArgumentException>(() => _service.ValidateForStockQuery(device));
         }
@@ -150,14 +149,7 @@ namespace Pirat.Tests
             personal = _captainHookGenerator.GeneratePersonal();
             personal.area = "";
             Assert.Throws<ArgumentException>(() => _service.ValidateForChangeInformation(_dummyToken, personal));
-
-            personal = _captainHookGenerator.GeneratePersonal();
-            personal.address.postalcode = "";
-            Assert.Throws<ArgumentException>(() => _service.ValidateForChangeInformation(_dummyToken, personal));
-
-            personal = _captainHookGenerator.GeneratePersonal();
-            personal.address.country = "";
-            Assert.Throws<ArgumentException>(() => _service.ValidateForChangeInformation(_dummyToken, personal));
+            
         }
 
         [Fact]
@@ -169,14 +161,6 @@ namespace Pirat.Tests
 
             device = _captainHookGenerator.GenerateDevice();
             device.category = "";
-            Assert.Throws<ArgumentException>(() => _service.ValidateForChangeInformation(_dummyToken, device));
-
-            device = _captainHookGenerator.GenerateDevice();
-            device.address.postalcode = "";
-            Assert.Throws<ArgumentException>(() => _service.ValidateForChangeInformation(_dummyToken, device));
-
-            device = _captainHookGenerator.GenerateDevice();
-            device.address.country = "";
             Assert.Throws<ArgumentException>(() => _service.ValidateForChangeInformation(_dummyToken, device));
         }
 
@@ -193,14 +177,6 @@ namespace Pirat.Tests
 
             consumable = _captainHookGenerator.GenerateConsumable();
             consumable.category = "";
-            Assert.Throws<ArgumentException>(() => _service.ValidateForChangeInformation(_dummyToken, consumable));
-
-            consumable = _captainHookGenerator.GenerateConsumable();
-            consumable.address.postalcode = "";
-            Assert.Throws<ArgumentException>(() => _service.ValidateForChangeInformation(_dummyToken, consumable));
-
-            consumable = _captainHookGenerator.GenerateConsumable();
-            consumable.address.country = "";
             Assert.Throws<ArgumentException>(() => _service.ValidateForChangeInformation(_dummyToken, consumable));
         }
 

--- a/Pirat.Tests/ResourceStockInputValidatorTest.cs
+++ b/Pirat.Tests/ResourceStockInputValidatorTest.cs
@@ -98,7 +98,7 @@ namespace Pirat.Tests
         [Fact]
         public void QueryManpower_BadInputs()
         {
-            var manpower = _captainHookGenerator.GenerateManpower();
+            var manpower = _captainHookGenerator.GenerateQueryManpower();
             manpower.address.postalcode = "";
             Assert.Throws<ArgumentException>(() => _service.ValidateForStockQuery(manpower));
         }

--- a/Pirat/Codes/Codes.cs
+++ b/Pirat/Codes/Codes.cs
@@ -9,7 +9,7 @@
 
         public const string MoreThanOneOfferFromToken = "9000:MoreThanOneOfferFromToken";
         public const string UpdatesMadeInTooManyRows = "9001:UpdatesMadeInTooManyRows";
-        public const string ResourceWithoutRelatedAddress = "9002:ResourceWithoutRelatedAddress";
+
         public const string MoreThanOneDemandFromToken = "9003:MoreThanOneDemandFromToken";
 
     }

--- a/Pirat/Model/Api/Resource/Item.cs
+++ b/Pirat/Model/Api/Resource/Item.cs
@@ -51,7 +51,7 @@ namespace Pirat.Model.Api.Resource
 
         public bool Equals(Item other)
         {
-            if (!(address != null && address.Equals(other.address)))
+            if (address != null && other != null && !address.Equals(other.address))
             {
                 return false;
             }

--- a/Pirat/Model/Api/Resource/Item.cs
+++ b/Pirat/Model/Api/Resource/Item.cs
@@ -77,9 +77,18 @@ namespace Pirat.Model.Api.Resource
 
         public override string ToString()
         {
+            var addressOutput = "";
+            if (address is null)
+            {
+                addressOutput = "null";
+            }
+            else
+            {
+                addressOutput = address.ToString();
+            }
             return $"id={id}, category={category}, name={name}, " +
                    $"manufacturer={manufacturer}, ordernumber={ordernumber}, " +
-                   $"amount={amount}, annotation={annotation}, address={address.ToString()}," +
+                   $"amount={amount}, annotation={annotation}, address={addressOutput}," +
                    $"kilometer={kilometer}";
         }
     }

--- a/Pirat/Model/Api/Resource/Item.cs
+++ b/Pirat/Model/Api/Resource/Item.cs
@@ -51,6 +51,14 @@ namespace Pirat.Model.Api.Resource
 
         public bool Equals(Item other)
         {
+            if (!(address != null && address.Equals(other.address)))
+            {
+                return false;
+            }
+            if (address == null && other.address != null)
+            {
+                return false;
+            }
             return other != null
                    && id == other.id
                    && string.Equals(category, other.category, StringComparison.Ordinal)
@@ -59,7 +67,6 @@ namespace Pirat.Model.Api.Resource
                    && string.Equals(ordernumber, other.ordernumber, StringComparison.Ordinal)
                    && amount == other.amount
                    && string.Equals(annotation, other.annotation, StringComparison.Ordinal)
-                   && Equals(address, other.address)
                    && kilometer == other.kilometer;
         }
 

--- a/Pirat/Model/Api/Resource/Personal.cs
+++ b/Pirat/Model/Api/Resource/Personal.cs
@@ -76,7 +76,7 @@ namespace Pirat.Model.Api.Resource
         
         public bool Equals(Personal other)
         {
-            if (!(address != null && address.Equals(other.address)))
+            if (address != null && other != null && !address.Equals(other.address))
             {
                 return false;
             }

--- a/Pirat/Model/Api/Resource/Personal.cs
+++ b/Pirat/Model/Api/Resource/Personal.cs
@@ -104,8 +104,18 @@ namespace Pirat.Model.Api.Resource
 
         public override string ToString()
         {
+            var addressOutput = "";
+            if (address is null)
+            {
+                addressOutput = "null";
+            }
+            else
+            {
+                addressOutput = address.ToString();
+            }
             return "Personal={ " + $"{base.ToString()} institution={institution}, researchgroup={researchgroup}, " +
-                   $"experience_rt_pcr={experience_rt_pcr}, annotation={annotation}, qualification={qualification} area={area} address={address} kilometer={kilometer}" + " }";
+                   $"experience_rt_pcr={experience_rt_pcr}, annotation={annotation}, qualification={qualification} " +
+                   $"area={area} address={addressOutput} kilometer={kilometer}" + " }";
         }
     }
 

--- a/Pirat/Model/Api/Resource/Personal.cs
+++ b/Pirat/Model/Api/Resource/Personal.cs
@@ -76,6 +76,15 @@ namespace Pirat.Model.Api.Resource
         
         public bool Equals(Personal other)
         {
+            if (!(address != null && address.Equals(other.address)))
+            {
+                return false;
+            }
+            if (address == null && other.address != null)
+            {
+                return false;
+            }
+
             return other != null
                    && id == other.id
                    && string.Equals(institution, other.institution, StringComparison.Ordinal)
@@ -84,7 +93,6 @@ namespace Pirat.Model.Api.Resource
                    && string.Equals(annotation, other.annotation, StringComparison.Ordinal)
                    && string.Equals(qualification, other.qualification, StringComparison.Ordinal)
                    && string.Equals(area, other.area, StringComparison.Ordinal)
-                   && Equals(address, other.address)
                    && kilometer == other.kilometer;
         }
 

--- a/Pirat/Model/Api/Resource/Provider.cs
+++ b/Pirat/Model/Api/Resource/Provider.cs
@@ -70,13 +70,21 @@ namespace Pirat.Model.Api.Resource
 
         public bool Equals(Provider other)
         {
+            if (!(address != null && address.Equals(other.address)))
+            {
+                return false;
+            }
+            if(address == null && other.address != null)
+            {
+                return false;
+            }
+
             return other != null
                    && string.Equals(name, other.name, StringComparison.Ordinal)
                    && string.Equals(organisation, other.organisation, StringComparison.Ordinal)
                    && string.Equals(phone, other.phone, StringComparison.Ordinal)
                    && string.Equals(mail, other.mail, StringComparison.Ordinal)
                    && ispublic == other.ispublic
-                   && Equals(address, other.address)
                    && kilometer == other.kilometer;
         }
 

--- a/Pirat/Model/Entity/Resource/Stock/ConsumableEntity.cs
+++ b/Pirat/Model/Entity/Resource/Stock/ConsumableEntity.cs
@@ -25,14 +25,6 @@ namespace Pirat.Model.Entity.Resource.Stock
             return this;
         }
 
-        public ConsumableEntity Build(AddressEntity a)
-        {
-            NullCheck.ThrowIfNull<AddressEntity>(a);
-            address_id = a.id;
-            return this;
-        }
-
-        
         public async Task<IFindable> FindAsync(ResourceContext context, int id)
         {
             NullCheck.ThrowIfNull<ResourceContext>(context);

--- a/Pirat/Model/Entity/Resource/Stock/DeviceEntity.cs
+++ b/Pirat/Model/Entity/Resource/Stock/DeviceEntity.cs
@@ -20,13 +20,6 @@ namespace Pirat.Model.Entity.Resource.Stock
             return this;
         }
 
-        public DeviceEntity Build(AddressEntity a)
-        {
-            NullCheck.ThrowIfNull<AddressEntity>(a);
-            address_id = a.id;
-            return this;
-        }
-
         public async Task<IFindable> FindAsync(ResourceContext context, int id)
         {
             NullCheck.ThrowIfNull<ResourceContext>(context);

--- a/Pirat/Model/Entity/Resource/Stock/ItemEntity.cs
+++ b/Pirat/Model/Entity/Resource/Stock/ItemEntity.cs
@@ -18,8 +18,6 @@
 
         public int offer_id { get; set; }
 
-        public int address_id { get; set; }
-
         public bool is_deleted { get; set; }
     }
 

--- a/Pirat/Model/Entity/Resource/Stock/PersonalEntity.cs
+++ b/Pirat/Model/Entity/Resource/Stock/PersonalEntity.cs
@@ -20,8 +20,6 @@ namespace Pirat.Model.Entity.Resource.Stock
 
         public int offer_id { get; set; }
 
-        public int address_id { get; set; }
-
         public string qualification { get; set; }
 
         public string area { get; set; }
@@ -37,13 +35,6 @@ namespace Pirat.Model.Entity.Resource.Stock
             annotation = p.annotation;
             qualification = p.qualification;
             area = p.area;
-            return this;
-        }
-
-        public PersonalEntity Build(AddressEntity a)
-        {
-            NullCheck.ThrowIfNull<AddressEntity>(a);
-            address_id = a.id;
             return this;
         }
 

--- a/Pirat/Services/Mail/SubscriptionService.cs
+++ b/Pirat/Services/Mail/SubscriptionService.cs
@@ -58,7 +58,7 @@ namespace Pirat.Services.Mail
             var queryAllRecentDevices = 
                 from o in _context.offer as IQueryable<OfferEntity>
                 join d in _context.device on o.id equals d.offer_id
-                join a in _context.address on d.address_id equals a.id
+                join a in _context.address on o.address_id equals a.id
                 where (o.timestamp > DateTime.Now.AddDays(-1))
                 select new { device = d, address = a };
             var allRecentDevices = await queryAllRecentDevices.ToListAsync();
@@ -66,7 +66,7 @@ namespace Pirat.Services.Mail
             var queryAllRecentConsumables = 
                 from o in _context.offer as IQueryable<OfferEntity>
                 join c in _context.consumable on o.id equals c.offer_id
-                join a in _context.address on c.address_id equals a.id
+                join a in _context.address on o.address_id equals a.id
                 where (o.timestamp > DateTime.Now.AddDays(-1))
                 select new { consumable = c, address = a };
             var allRecentConsumables = await queryAllRecentConsumables.ToListAsync();
@@ -74,7 +74,7 @@ namespace Pirat.Services.Mail
             var queryAllRecentPersonnel = 
                 from o in _context.offer as IQueryable<OfferEntity>
                 join p in _context.personal on o.id equals p.offer_id
-                join a in _context.address on p.address_id equals a.id
+                join a in _context.address on o.address_id equals a.id
                 where (o.timestamp > DateTime.Now.AddDays(-1))
                 select new { personnel = p, address = a };
             var allRecentPersonnel = await queryAllRecentPersonnel.ToListAsync();

--- a/Pirat/Services/Resource/ResourceStockInputValidatorService.cs
+++ b/Pirat/Services/Resource/ResourceStockInputValidatorService.cs
@@ -54,8 +54,6 @@ namespace Pirat.Services.Resource
             {
                 throw new ArgumentException(FailureCodes.IncompleteConsumable);
             }
-
-            validateAddress(consumable.address);
         }
 
         private void validateInformation(Device device)
@@ -64,7 +62,6 @@ namespace Pirat.Services.Resource
             {
                 throw new ArgumentException(FailureCodes.IncompleteDevice);
             }
-            validateAddress(device.address);
         }
 
         private void validateInformation(Personal personal)
@@ -73,8 +70,6 @@ namespace Pirat.Services.Resource
             {
                 throw new ArgumentException(FailureCodes.IncompletePersonal);
             }
-
-            validateAddress(personal.address);
         }
 
 

--- a/Pirat/Services/Resource/ResourceStockQueryService.cs
+++ b/Pirat/Services/Resource/ResourceStockQueryService.cs
@@ -79,9 +79,6 @@ namespace Pirat.Services.Resource
                 }
                 resource.kilometer = (int)Math.Round(distance);
 
-                //Give resource empty address
-                resource.address = new Address();
-
                 var provider = new Provider().Build(data.o);
                 var providerAddress = new Address().Build(data.ap);
 
@@ -149,9 +146,6 @@ namespace Pirat.Services.Resource
                     continue;
                 }
                 resource.kilometer = (int)Math.Round(distance);
-
-                //Give resource empty address
-                resource.address = new Address();
 
                 var provider = new Provider().Build(data.o);
                 var providerAddress = new Address().Build(data.ap);
@@ -228,9 +222,6 @@ namespace Pirat.Services.Resource
                     continue;
                 }
                 resource.kilometer = (int)Math.Round(distance);
-
-                //Give resource empty address
-                resource.address = new Address();
 
                 var provider = new Provider().Build(data.o);
                 var providerAddress = new Address().Build(data.ap);

--- a/Pirat/Services/Resource/ResourceStockQueryService.cs
+++ b/Pirat/Services/Resource/ResourceStockQueryService.cs
@@ -257,7 +257,6 @@ namespace Pirat.Services.Resource
         {
             var offerEntity = await _queryHelper.RetrieveOfferFromTokenAsync(token);
             var offerKey = offerEntity.id;
-            var providerAddressKey = offerEntity.address_id;
 
             //Build the provider from the offerEntity and the address we retrieve from the address id
 
@@ -272,7 +271,7 @@ namespace Pirat.Services.Resource
             foreach (var c in consumableEntities)
             {
                 if (c.is_deleted) continue;
-                offer.consumables.Add(new Consumable().build(c).build(await _queryHelper.QueryAddressAsync(providerAddressKey)));
+                offer.consumables.Add(new Consumable().build(c));
             }
 
             var queD = from d in _context.device as IQueryable<DeviceEntity> where d.offer_id == offerKey select d;
@@ -280,7 +279,7 @@ namespace Pirat.Services.Resource
             foreach (var d in deviceEntities)
             {
                 if(d.is_deleted) continue;
-                offer.devices.Add(new Device().Build(d).Build(await _queryHelper.QueryAddressAsync(providerAddressKey)));
+                offer.devices.Add(new Device().Build(d));
             }
 
             var queP = from p in _context.personal as IQueryable<PersonalEntity> where p.offer_id == offerKey select p;
@@ -288,7 +287,7 @@ namespace Pirat.Services.Resource
             foreach (var p in personalEntities)
             {
                 if(p.is_deleted) continue;
-                offer.personals.Add(new Personal().build(p).build(await _queryHelper.QueryAddressAsync(providerAddressKey)));
+                offer.personals.Add(new Personal().build(p));
             }
 
             return offer;

--- a/Pirat/Services/Resource/ResourceStockQueryService.cs
+++ b/Pirat/Services/Resource/ResourceStockQueryService.cs
@@ -79,6 +79,9 @@ namespace Pirat.Services.Resource
                 }
                 resource.kilometer = (int)Math.Round(distance);
 
+                //Give resource empty address
+                resource.address = new Address();
+
                 var provider = new Provider().Build(data.o);
                 var providerAddress = new Address().Build(data.ap);
 
@@ -146,6 +149,9 @@ namespace Pirat.Services.Resource
                     continue;
                 }
                 resource.kilometer = (int)Math.Round(distance);
+
+                //Give resource empty address
+                resource.address = new Address();
 
                 var provider = new Provider().Build(data.o);
                 var providerAddress = new Address().Build(data.ap);
@@ -222,6 +228,9 @@ namespace Pirat.Services.Resource
                     continue;
                 }
                 resource.kilometer = (int)Math.Round(distance);
+
+                //Give resource empty address
+                resource.address = new Address();
 
                 var provider = new Provider().Build(data.o);
                 var providerAddress = new Address().Build(data.ap);

--- a/Pirat/Services/Resource/ResourceStockQueryService.cs
+++ b/Pirat/Services/Resource/ResourceStockQueryService.cs
@@ -47,9 +47,8 @@ namespace Pirat.Services.Resource
             var query = from o in _context.offer as IQueryable<OfferEntity>
                         join c in _context.consumable on o.id equals c.offer_id
                         join ap in _context.address on o.address_id equals ap.id
-                        join ac in _context.address on c.address_id equals ac.id
                         where consumable.category == c.category && !c.is_deleted && o.region == region
-                        select new { o, c, ap, ac };
+                        select new { o, c, ap };
 
             if (!string.IsNullOrEmpty(consumable.name))
             {
@@ -71,8 +70,8 @@ namespace Pirat.Services.Resource
 
                 var resource = new Consumable().build(data.c);
 
-                var yLatitude = data.ac.latitude;
-                var yLongitude = data.ac.longitude;
+                var yLatitude = data.ap.latitude;
+                var yLongitude = data.ap.longitude;
                 var distance = DistanceCalculator.computeDistance(location.latitude, location.longitude, yLatitude, yLongitude);
                 if (distance > maxDistance && maxDistance != 0)
                 {
@@ -82,10 +81,8 @@ namespace Pirat.Services.Resource
 
                 var provider = new Provider().Build(data.o);
                 var providerAddress = new Address().Build(data.ap);
-                var resourceAddress = new Address().Build(data.ac);
 
                 provider.address = providerAddress;
-                resource.address = resourceAddress;
 
                 var offer = new OfferResource<Consumable>()
                 {
@@ -118,9 +115,8 @@ namespace Pirat.Services.Resource
             var query = from o in _context.offer as IQueryable<OfferEntity>
                         join d in _context.device on o.id equals d.offer_id
                         join ap in _context.address on o.address_id equals ap.id
-                        join ac in _context.address on d.address_id equals ac.id
                         where device.category == d.category && !d.is_deleted && o.region == region
-                        select new { o, d, ap, ac };
+                        select new { o, d, ap };
 
             if (!string.IsNullOrEmpty(device.name))
             {
@@ -141,8 +137,8 @@ namespace Pirat.Services.Resource
             {
                 var resource = new Device().Build(data.d);
 
-                var yLatitude = data.ac.latitude;
-                var yLongitude = data.ac.longitude;
+                var yLatitude = data.ap.latitude;
+                var yLongitude = data.ap.longitude;
                 var distance = DistanceCalculator.computeDistance(location.latitude, location.longitude, yLatitude, yLongitude);
 
                 if (distance > maxDistance && maxDistance != 0)
@@ -153,10 +149,8 @@ namespace Pirat.Services.Resource
 
                 var provider = new Provider().Build(data.o);
                 var providerAddress = new Address().Build(data.ap);
-                var resourceAddress = new Address().Build(data.ac);
 
                 provider.address = providerAddress;
-                resource.address = resourceAddress;
                 var offer = new OfferResource<Device>()
                 {
                     resource = resource
@@ -188,9 +182,8 @@ namespace Pirat.Services.Resource
             var query = from o in _context.offer as IQueryable<OfferEntity>
                         join personal in _context.personal on o.id equals personal.offer_id
                         join ap in _context.address on o.address_id equals ap.id
-                        join ac in _context.address on personal.address_id equals ac.id
                         where !personal.is_deleted && o.region == region
-                        select new { o, personal, ap, ac };
+                        select new { o, personal, ap };
 
             if (!string.IsNullOrEmpty(manpower.institution))
             {
@@ -221,8 +214,8 @@ namespace Pirat.Services.Resource
             {
                 var resource = new Personal().build(data.personal);
 
-                var yLatitude = data.ac.latitude;
-                var yLongitude = data.ac.longitude;
+                var yLatitude = data.ap.latitude;
+                var yLongitude = data.ap.longitude;
                 var distance = DistanceCalculator.computeDistance(location.latitude, location.longitude, yLatitude, yLongitude);
                 if (distance > maxDistance && maxDistance != 0)
                 {
@@ -232,10 +225,8 @@ namespace Pirat.Services.Resource
 
                 var provider = new Provider().Build(data.o);
                 var providerAddress = new Address().Build(data.ap);
-                var resourceAddress = new Address().Build(data.ac);
 
                 provider.address = providerAddress;
-                resource.address = resourceAddress;
 
                 var offer = new OfferResource<Personal>()
                 {
@@ -266,6 +257,7 @@ namespace Pirat.Services.Resource
         {
             var offerEntity = await _queryHelper.RetrieveOfferFromTokenAsync(token);
             var offerKey = offerEntity.id;
+            var providerAddressKey = offerEntity.address_id;
 
             //Build the provider from the offerEntity and the address we retrieve from the address id
 
@@ -280,7 +272,7 @@ namespace Pirat.Services.Resource
             foreach (var c in consumableEntities)
             {
                 if (c.is_deleted) continue;
-                offer.consumables.Add(new Consumable().build(c).build(await _queryHelper.QueryAddressAsync(c.address_id)));
+                offer.consumables.Add(new Consumable().build(c).build(await _queryHelper.QueryAddressAsync(providerAddressKey)));
             }
 
             var queD = from d in _context.device as IQueryable<DeviceEntity> where d.offer_id == offerKey select d;
@@ -288,7 +280,7 @@ namespace Pirat.Services.Resource
             foreach (var d in deviceEntities)
             {
                 if(d.is_deleted) continue;
-                offer.devices.Add(new Device().Build(d).Build(await _queryHelper.QueryAddressAsync(d.address_id)));
+                offer.devices.Add(new Device().Build(d).Build(await _queryHelper.QueryAddressAsync(providerAddressKey)));
             }
 
             var queP = from p in _context.personal as IQueryable<PersonalEntity> where p.offer_id == offerKey select p;
@@ -296,7 +288,7 @@ namespace Pirat.Services.Resource
             foreach (var p in personalEntities)
             {
                 if(p.is_deleted) continue;
-                offer.personals.Add(new Personal().build(p).build(await _queryHelper.QueryAddressAsync(p.address_id)));
+                offer.personals.Add(new Personal().build(p).build(await _queryHelper.QueryAddressAsync(providerAddressKey)));
             }
 
             return offer;

--- a/Pirat/Services/Resource/ResourceStockUpdateService.cs
+++ b/Pirat/Services/Resource/ResourceStockUpdateService.cs
@@ -181,10 +181,7 @@ namespace Pirat.Services.Resource
         public async Task<int> ChangeInformationAsync(string token, Consumable consumable)
         {
             NullCheck.ThrowIfNull<Consumable>(consumable);
-
-            AddressEntity location = new AddressEntity().build(consumable.address);
-            _addressMaker.SetCoordinates(location);
-
+            
             var query = 
                 from o in _context.offer as IQueryable<OfferEntity>
                 join c in _context.consumable on o.id equals c.offer_id
@@ -213,10 +210,7 @@ namespace Pirat.Services.Resource
         public async Task<int> ChangeInformationAsync(string token, Device device)
         {
             NullCheck.ThrowIfNull<Device>(device);
-
-            AddressEntity location = new AddressEntity().build(device.address);
-            _addressMaker.SetCoordinates(location);
-
+            
             var query = 
                 from o in _context.offer as IQueryable<OfferEntity>
                 join d in _context.device on o.id equals d.offer_id
@@ -244,10 +238,7 @@ namespace Pirat.Services.Resource
         public async Task<int> ChangeInformationAsync(string token, Personal personal)
         {
             NullCheck.ThrowIfNull<Personal>(personal);
-
-            AddressEntity location = new AddressEntity().build(personal.address);
-            _addressMaker.SetCoordinates(location);
-
+            
             var query = 
                 from o in _context.offer as IQueryable<OfferEntity>
                 join p in _context.personal on o.id equals p.offer_id

--- a/Pirat/Services/Resource/ResourceStockUpdateService.cs
+++ b/Pirat/Services/Resource/ResourceStockUpdateService.cs
@@ -39,8 +39,6 @@ namespace Pirat.Services.Resource
 
         /// <summary>
         /// Inserts a consumable entity into the database which gets <c>offerId</c> as foreign key for the offer entity it relates to.
-        /// In addition, an address entity is created based on the address information in <c>consumable</c> and is inserted into the
-        /// database with relation to the new consumable entity.
         /// </summary>
         /// <param name="offerId">The unique id of the offer</param>
         /// <param name="consumable">The consumable from which the entity is created</param>
@@ -48,22 +46,13 @@ namespace Pirat.Services.Resource
         private async Task InsertAsync(int offerId, Consumable consumable)
         {
             var consumableEntity = new ConsumableEntity().Build(consumable);
-            var addressEntity = new AddressEntity().build(consumable.address);
-
-            _addressMaker.SetCoordinates(addressEntity);
-            await addressEntity.InsertAsync(_context);
-
             consumableEntity.offer_id = offerId;
-            consumableEntity.address_id = addressEntity.id;
             await consumableEntity.InsertAsync(_context);
-
             consumable.id = consumableEntity.id;
         }
 
         /// <summary>
-        /// Inserts a device entity into the database which gets <c>offerId</c> as foreign key for the offer entity it relates to.
-        /// In addition, an address entity is created based on the address information in <c>device</c> and is inserted into the
-        /// database with relation to the new device entity.
+        /// Inserts a device entity into the database which gets <c>offerId</c> as foreign key for the offer entity it relates to
         /// </summary>
         /// <param name="offerId">The unique id of the offer</param>
         /// <param name="device">The device from which the entity is created</param>
@@ -71,22 +60,13 @@ namespace Pirat.Services.Resource
         private async Task InsertAsync(int offerId, Device device)
         {
             var deviceEntity = new DeviceEntity().Build(device);
-            var addressEntity = new AddressEntity().build(device.address);
-
-            _addressMaker.SetCoordinates(addressEntity);
-            await addressEntity.InsertAsync(_context);
-
             deviceEntity.offer_id = offerId;
-            deviceEntity.address_id = addressEntity.id;
             await deviceEntity.InsertAsync(_context);
-
             device.id = deviceEntity.id;
         }
 
         /// <summary>
         /// Inserts a personal entity into the database which gets <c>offerId</c> as foreign key for the personal entity it relates to.
-        /// In addition, an address entity is created based on the address information in <c>personal</c> and is inserted into the
-        /// database with relation to the new personal entity.
         /// </summary>
         /// <param name="offerId">The unique id of the offer</param>
         /// <param name="personal">The personal from which the entity is created</param>
@@ -94,15 +74,8 @@ namespace Pirat.Services.Resource
         private async Task InsertAsync(int offerId, Personal personal)
         {
             var personEntity = new PersonalEntity().Build(personal);
-            var addressEntity = new AddressEntity().build(personal.address);
-
-            _addressMaker.SetCoordinates(addressEntity);
-            await addressEntity.InsertAsync(_context);
-
             personEntity.offer_id = offerId;
-            personEntity.address_id = addressEntity.id;
             await personEntity.InsertAsync(_context);
-
             personal.id = personEntity.id;
         }
 
@@ -215,9 +188,8 @@ namespace Pirat.Services.Resource
             var query = 
                 from o in _context.offer as IQueryable<OfferEntity>
                 join c in _context.consumable on o.id equals c.offer_id
-                join ac in _context.address on c.address_id equals ac.id
                 where o.token == token && c.id == consumable.id
-                select new {o, c, ac};
+                select new {o, c};
 
             foreach(var collection in await query.ToListAsync())
             {
@@ -226,12 +198,11 @@ namespace Pirat.Services.Resource
                 collection.c.name = consumable.name;
                 collection.c.manufacturer = consumable.manufacturer;
                 collection.c.ordernumber = consumable.ordernumber;
-                collection.ac.OverwriteWith(location);
             }
 
             var changedRows = await _context.SaveChangesAsync();
 
-            if (2 < changedRows)
+            if (1 < changedRows)
             {
                 throw new InvalidDataStateException(FatalCodes.UpdatesMadeInTooManyRows);
             }
@@ -249,9 +220,8 @@ namespace Pirat.Services.Resource
             var query = 
                 from o in _context.offer as IQueryable<OfferEntity>
                 join d in _context.device on o.id equals d.offer_id
-                join ad in _context.address on d.address_id equals ad.id
                 where o.token == token && d.id == device.id
-                select new { o, d, ad };
+                select new { o, d };
 
             foreach (var collection in await query.ToListAsync())
             {
@@ -259,12 +229,11 @@ namespace Pirat.Services.Resource
                 collection.d.name = device.name;
                 collection.d.manufacturer = device.manufacturer;
                 collection.d.ordernumber = device.ordernumber;
-                collection.ad.OverwriteWith(location);
             }
 
             var changedRows = await _context.SaveChangesAsync();
 
-            if (2 < changedRows)
+            if (1 < changedRows)
             {
                 throw new InvalidDataStateException(FatalCodes.UpdatesMadeInTooManyRows);
             }
@@ -282,9 +251,8 @@ namespace Pirat.Services.Resource
             var query = 
                 from o in _context.offer as IQueryable<OfferEntity>
                 join p in _context.personal on o.id equals p.offer_id
-                join ap in _context.address on p.address_id equals ap.id
                 where o.token == token && p.id == personal.id
-                select new {o, p, ap};
+                select new {o, p};
 
             foreach (var collection in await query.ToListAsync())
             {
@@ -294,12 +262,11 @@ namespace Pirat.Services.Resource
                 collection.p.researchgroup = personal.researchgroup;
                 collection.p.annotation = personal.annotation;
                 collection.p.experience_rt_pcr = personal.experience_rt_pcr;
-                collection.ap.OverwriteWith(location);
             }
 
             var changedRows = await _context.SaveChangesAsync();
 
-            if (2 < changedRows)
+            if (1 < changedRows)
             {
                 throw new InvalidDataStateException(FatalCodes.UpdatesMadeInTooManyRows);
             }
@@ -528,20 +495,10 @@ namespace Pirat.Services.Resource
 
             ConsumableEntity consumableEntity = foundConsumables[0].c;
             OfferEntity offerEntity = foundConsumables[0].o;
-
-            AddressEntity addressEntity = (AddressEntity) await new AddressEntity().FindAsync(_context, consumableEntity.address_id);
-
-            if (addressEntity is null)
-            {
-                throw new InvalidDataStateException(FatalCodes.ResourceWithoutRelatedAddress);
-            }
-
+            
             consumableEntity.is_deleted = true;
             await consumableEntity.UpdateAsync(_context);
-
-            addressEntity.is_deleted = true;
-            await addressEntity.UpdateAsync(_context);
-
+            
             await new ChangeEntity()
             {
                 change_type = ChangeEntityChangeType.DeleteResource,
@@ -583,19 +540,9 @@ namespace Pirat.Services.Resource
             DeviceEntity deviceEntity = foundDevices[0].d;
             OfferEntity offerEntity = foundDevices[0].o;
 
-            AddressEntity addressEntity = (AddressEntity) await new AddressEntity().FindAsync(_context, deviceEntity.address_id);
-            
-            if (addressEntity is null)
-            {
-                throw new InvalidDataStateException(FatalCodes.ResourceWithoutRelatedAddress);
-            }
-
             deviceEntity.is_deleted = true;
             await deviceEntity.UpdateAsync(_context);
-
-            addressEntity.is_deleted = true;
-            await addressEntity.UpdateAsync(_context);
-
+            
             await new ChangeEntity()
             {
                 change_type = ChangeEntityChangeType.DeleteResource,
@@ -636,19 +583,8 @@ namespace Pirat.Services.Resource
             PersonalEntity personalEntity = foundPersonals[0].p;
             OfferEntity offerEntity = foundPersonals[0].o;
 
-            AddressEntity addressEntity = (AddressEntity)await new AddressEntity().FindAsync(_context, personalEntity.address_id);
-
-
-            if (addressEntity is null)
-            {
-                throw new InvalidDataStateException(FatalCodes.ResourceWithoutRelatedAddress);
-            }
-
             personalEntity.is_deleted = true;
             await personalEntity.UpdateAsync(_context);
-
-            addressEntity.is_deleted = true;
-            await addressEntity.UpdateAsync(_context);
 
             await new ChangeEntity()
             {

--- a/init.sql
+++ b/init.sql
@@ -50,10 +50,6 @@ create table consumable
 		constraint consumable_offer_id_fk
 			references offer
 				on update cascade on delete cascade,
-	address_id integer not null
-		constraint consumable_address_id_fk
-			references address
-				on update cascade on delete cascade,
 	unit text,
 	annotation text,
 	is_deleted boolean default false not null
@@ -76,10 +72,6 @@ create table device
 		constraint device_offer_id_fk
 			references offer
 				on update cascade on delete cascade,
-	address_id integer not null
-		constraint device_address_id_fk
-			references address
-				on update cascade on delete cascade,
 	annotation text,
 	is_deleted boolean default false not null
 );
@@ -101,10 +93,6 @@ create table personal
 	offer_id integer
 		constraint personal_offer_id_fk
 			references offer
-				on update cascade on delete cascade,
-	address_id integer
-		constraint personal_address_id_fk
-			references address
 				on update cascade on delete cascade,
 	is_deleted boolean default false not null
 );


### PR DESCRIPTION
Address is only part of resources (in api folder) if part of query.

Enities have no address id anymore. If testing with real developer database then the ids must be removed.

In queries for resources the address of the provider is taken for distance computation.

In the response of queries address is set to null when it will be sent from the BE to the FE.

Inputvalidator checks only address existence for queries.

Revised equal and tostring function of Item.cs and Personal.cs because of null possibility of address.

Tests needed some changes. Revised Generator classes.